### PR TITLE
Cria comando para baixar biblioteca de declarações de tipo do Fluig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,6 @@ Adição do snippet JavaScript (fluig-paifilho-loop-workflow) para percorrer Pai
 
 Adição do snippet JavaScript (fluig-consulta-jdbc) para facilitar consulta direta ao Banco de Dados com JDBC.
 
-
 ## 1.5.0
 
 Adição dos comandos:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Lista de atualizações da Extensão.
 
+## 1.17.0
+
+Adiciona o comando `Instalar Declarações de Tipo` para instalar a biblioteca de declarações de tipo puxando os
+arquivos mais atualizados do GitHub.
+
 ## 1.16.0
 
 Adiciona atalhos para:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Essa extensão cria os arquivos utilizando os tipos declarados na biblioteca [De
 para o Fluig](https://github.com/fluiggers/fluig-declaration-type) para ter auto-complete no
 VS Code, por isso é recomendado que ela seja instalada.
 
+Você pode instalar a **Declaração de Tipos para o Fluig** baixando o último release disponibilizado no GitHub ou
+pode executar o comando `Fluig: Instalar Declarações de Tipo`, no **Command Palette** (normalmente com a tecla de atalho F1),
+para que a Extensão baixe os arquivos para o seu workspace / diretório.
+
 ## Como utilizar
 
 Para utilizar os comandos de criação de arquivos é obrigatório estar com um diretório / workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluig-vscode-extension",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "fluig-vscode-extension",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "devDependencies": {
                 "@popperjs/core": "^2.11.6",
                 "@types/crypto-js": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluig-vscode-extension",
     "displayName": "Fluig - Extensão VS Code",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "publisher": "BrunoGasparetto",
     "repository": {
         "type": "git",
@@ -182,6 +182,10 @@
                 },
                 {
                     "command": "fluig-vscode-extension.editServer",
+                    "when": "false"
+                },
+                {
+                    "command": "fluig-vscode-extension.datasetView",
                     "when": "false"
                 }
             ],

--- a/package.json
+++ b/package.json
@@ -45,11 +45,17 @@
         "onCommand:fluig-vscode-extension.importGlobalEvent",
         "onCommand:fluig-vscode-extension.importManyGlobalEvent",
         "onCommand:fluig-vscode-extension.datasetView",
+        "onCommand:fluig-vscode-extension.installDeclarationLibrary",
         "onView:fluig-vscode-extension.servers"
     ],
     "main": "./dist/extension.js",
     "contributes": {
         "commands": [
+            {
+                "command": "fluig-vscode-extension.installDeclarationLibrary",
+                "title": "Instalar Declarações de Tipo",
+                "category": "Fluig"
+            },
             {
                 "command": "fluig-vscode-extension.newDataset",
                 "title": "Novo Dataset",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -463,6 +463,11 @@ function getTemplatesNameFromPath(path: string): string[] {
 }
 
 function installDeclarationLibrary() {
+    if (!vscode.workspace.workspaceFolders) {
+        vscode.window.showInformationMessage("Você precisa estar em um diretório / workspace.");
+        return;
+    }
+
     const axiosConfig: AxiosRequestConfig = {
         responseType: "stream"
     };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,13 @@
 import * as vscode from "vscode";
 import { posix } from "path";
-import { readFileSync } from "fs";
+import { readFileSync, createWriteStream } from "fs";
 import { DatasetItem, ServerItem, ServerItemProvider } from "./providers/ServerItemProvider";
+import axios, { AxiosRequestConfig } from "axios";
 import { glob } from "glob";
 import { DatasetService } from "./services/DatasetService";
 import { FormService } from "./services/FormService";
 import { GlobalEventService } from "./services/GlobalEventService";
+import { UtilsService } from "./services/UtilsService";
 
 interface ExtensionsPath {
     TEMPLATES: string,
@@ -52,6 +54,10 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.commands.registerCommand("fluig-vscode-extension.newGlobalEvent", createGlobalEvent)
+    );
+
+    context.subscriptions.push(
+        vscode.commands.registerCommand("fluig-vscode-extension.installDeclarationLibrary", installDeclarationLibrary)
     );
 
     EXTENSION_PATHS.TEMPLATES = getTemplateDirectoryPath(context);
@@ -454,6 +460,22 @@ function getTemplateDirectoryPath(context: vscode.ExtensionContext): string {
 function getTemplatesNameFromPath(path: string): string[] {
     return glob.sync(posix.join(path, '*.txt'))
         .map(filename => posix.basename(filename).replace(/([^.]+)\.txt/, '$1'));
+}
+
+function installDeclarationLibrary() {
+    const axiosConfig: AxiosRequestConfig = {
+        responseType: "stream"
+    };
+
+    Promise.all([
+        axios.get("https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/jsconfig.json", axiosConfig),
+        axios.get("https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/fluig.d.ts", axiosConfig)
+    ])
+    .then(function ([jsConfig, fluigDeclarations]) {
+        jsConfig.data.pipe(createWriteStream(posix.join(UtilsService.getWorkspace(), "jsconfig.json")));
+        fluigDeclarations.data.pipe(createWriteStream(posix.join(UtilsService.getWorkspace(), "fluig.d.ts")));
+    })
+    .catch(() => vscode.window.showErrorMessage("Erro ao baixar biblioteca do GitHub. Verifique sua conexão com a Internet"));
 }
 
 /**


### PR DESCRIPTION
Novo comando permite baixar a biblioteca atualizada do GitHub para ter um auto-complete do Fluig no VS Code.