### PR TITLE
Corrige falha de não identificar o nome do dataset em ambientes Mac / Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Lista de atualizações da Extensão.
 
+## 1.19.4
+
+- Aumenta a versão do motor do VSCode;
+- Altera como determina o caminho dos arquivos para utilizar a `vscode.Uri`, evitando problemas com o módulo `path`;
+- Utiliza a `path.basename` para determinar o nome do Dataset ao exportar, corrigindo problema de não pré-selecionar a opção em Mac / Unix;
+
 ## 1.19.3
 
 - Instala atualizações de segurança de várias dependências do projeto;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Lista de atualizações da Extensão.
 
+## 1.19.3
+
+- Instala atualizações de segurança de várias dependências do projeto;
+- Aumenta a versão do engine do VS Code para ^1.75.0;
+
 ## 1.19.0
 
 Altera o publicador da Extensão, a passando para a comunidade Fluiggers.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -161,7 +161,7 @@ exports.default = series(
 
 exports.clean = clean;
 
-exports.buildLibrarys = parallel([
+exports.buildLibraries = parallel([
     buildJquery,
     buildBootstrapCss,
     buildBootstrapJs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2245,9 +2245,9 @@
             }
         },
         "node_modules/decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.10"
@@ -10099,9 +10099,9 @@
             }
         },
         "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "dev": true
         },
         "deep-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4870,9 +4870,9 @@
             }
         },
         "node_modules/loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dev": true,
             "dependencies": {
                 "big.js": "^5.2.2",
@@ -12196,9 +12196,9 @@
             "dev": true
         },
         "loader-utils": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-            "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+            "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -8899,9 +8899,9 @@
             "requires": {}
         },
         "@xmldom/xmldom": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-            "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+            "version": "0.7.9",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.9.tgz",
+            "integrity": "sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==",
             "dev": true
         },
         "@xtuc/ieee754": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "1.19.2",
+    "version": "1.19.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "1.19.2",
+            "version": "1.19.3",
             "devDependencies": {
                 "@popperjs/core": "^2.11.6",
                 "@types/crypto-js": "^4.0.2",
@@ -46,7 +46,7 @@
                 "webpack-cli": "^4.7.0"
             },
             "engines": {
-                "vscode": "^1.56.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "1.19.3",
+    "version": "1.19.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "1.19.3",
+            "version": "1.19.4",
             "devDependencies": {
                 "@popperjs/core": "^2.11.6",
                 "@types/crypto-js": "^4.0.2",
@@ -8107,9 +8107,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.74.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-            "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -14745,9 +14745,9 @@
             }
         },
         "webpack": {
-            "version": "5.74.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-            "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+            "version": "5.76.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+            "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4671,9 +4671,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "bin": {
                 "json5": "lib/cli.js"
@@ -12035,9 +12035,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true
         },
         "jsprim": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.19.3",
+    "version": "1.19.4",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.19.2",
+    "version": "1.19.3",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {
@@ -21,34 +21,12 @@
         }
     ],
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.75.0"
     },
     "categories": [
         "Snippets",
         "Programming Languages",
         "Other"
-    ],
-    "activationEvents": [
-        "onCommand:fluiggers-fluig-vscode-extension.newDataset",
-        "onCommand:fluiggers-fluig-vscode-extension.newForm",
-        "onCommand:fluiggers-fluig-vscode-extension.newFormEvent",
-        "onCommand:fluiggers-fluig-vscode-extension.newWorkflowEvent",
-        "onCommand:fluiggers-fluig-vscode-extension.newGlobalEvent",
-        "onCommand:fluiggers-fluig-vscode-extension.newMechanism",
-        "onCommand:fluiggers-fluig-vscode-extension.addServer",
-        "onCommand:fluiggers-fluig-vscode-extension.deleteServer",
-        "onCommand:fluiggers-fluig-vscode-extension.refreshServer",
-        "onCommand:fluiggers-fluig-vscode-extension.editServer",
-        "onCommand:fluiggers-fluig-vscode-extension.importDataset",
-        "onCommand:fluiggers-fluig-vscode-extension.importManyDataset",
-        "onCommand:fluiggers-fluig-vscode-extension.exportDataset",
-        "onCommand:fluiggers-fluig-vscode-extension.importManyForm",
-        "onCommand:fluiggers-fluig-vscode-extension.importForm",
-        "onCommand:fluiggers-fluig-vscode-extension.importGlobalEvent",
-        "onCommand:fluiggers-fluig-vscode-extension.importManyGlobalEvent",
-        "onCommand:fluiggers-fluig-vscode-extension.datasetView",
-        "onCommand:fluiggers-fluig-vscode-extension.installDeclarationLibrary",
-        "onView:fluiggers-fluig-vscode-extension.servers"
     ],
     "main": "./dist/extension.js",
     "contributes": {
@@ -372,7 +350,7 @@
         "vscode:prepublish": "npm run package",
         "precompile": "gulp",
         "buildResources": "gulp buildResources",
-        "buildLibrarys": "gulp buildLibrarys",
+        "buildLibraries": "gulp buildLibraries",
         "compile": "webpack",
         "watch": "npm run precompile && webpack --watch",
         "package": "npm run precompile && webpack --mode production --devtool hidden-source-map",

--- a/src/services/DatasetService.ts
+++ b/src/services/DatasetService.ts
@@ -1,10 +1,9 @@
-import * as vscode from "vscode";
 import axios from "axios";
 import { ServerDTO } from "../models/ServerDTO";
 import * as https from 'https';
 import { ServerService } from "./ServerService";
 import { window, workspace, Uri } from "vscode";
-import { posix } from "path";
+import { basename } from "path";
 import { DatasetDTO } from "../models/DatasetDTO";
 import { DatasetStructureDTO } from "../models/DatasetStructureDTO";
 import { UtilsService } from "./UtilsService";
@@ -219,6 +218,7 @@ export class DatasetService {
     public static async getOptionsSelected(server: ServerDTO) {
         const datasets = await DatasetService.getDatasetsCustom(server);
         const items = datasets.map(dataset => ({ label: dataset.datasetId }));
+
         const result = await window.showQuickPick(items, {
             placeHolder: "Selecione o dataset",
             canPickMany: true
@@ -229,9 +229,7 @@ export class DatasetService {
             return;
         }
 
-        return result.map(async item => {
-            return await DatasetService.getDataset(server, item.label);
-        });
+        return result.map(async (item: any) => await DatasetService.getDataset(server, item.label));
     }
 
     /**
@@ -282,7 +280,7 @@ export class DatasetService {
             return;
         }
 
-        datasets.map(async item => {
+        datasets.map(async (item: any) => {
             const dataset = await item;
             DatasetService.saveFile(
                 dataset.data.datasetPK.datasetId,
@@ -303,24 +301,21 @@ export class DatasetService {
 
         const datasets = await DatasetService.getDatasetsCustom(server);
         const items = [];
-        const path = fileUri.fsPath.split("\\");
-        let datasetIdSelected: string = '';
-        let datasetId: string = '';
-        datasetId = path[path.length - 1];
-        datasetId = datasetId.replace('.js', '');
 
-        for(let dataset of datasets) {
-            if(dataset.datasetId !== datasetId) {
+        let datasetIdSelected: string = '';
+        let datasetId: string = basename(fileUri.fsPath, '.js');
+
+        for (let dataset of datasets) {
+            if (dataset.datasetId !== datasetId) {
                 items.push({ label: dataset.datasetId });
-            }
-            else {
+            } else {
                 datasetIdSelected = dataset.datasetId;
             }
         }
 
         items.unshift({ label: 'Novo dataset' });
 
-        if(datasetIdSelected !== '') {
+        if (datasetIdSelected !== '') {
             items.unshift({ label: datasetIdSelected });
         }
 
@@ -446,7 +441,7 @@ export class DatasetService {
         }
 
         const workspaceFolderUri = workspace.workspaceFolders[0].uri;
-        const datasetUri = workspaceFolderUri.with({ path: posix.join(workspaceFolderUri.path, "datasets", name + ".js") });
+        const datasetUri = Uri.joinPath(workspaceFolderUri, "datasets", name + ".js");
 
         await workspace.fs.writeFile(
             datasetUri,

--- a/src/services/GlobalEventService.ts
+++ b/src/services/GlobalEventService.ts
@@ -3,9 +3,9 @@ import { ServerDTO } from "../models/ServerDTO";
 import { UtilsService } from "./UtilsService";
 import * as https from 'https';
 import { GlobalEventDTO } from "../models/GlobalEventDTO";
-import { window, workspace } from "vscode";
+import { window, workspace, Uri } from "vscode";
 import { ServerService } from "./ServerService";
-import { posix } from "path";
+import * as path from "path";
 
 export class GlobalEventService {
 
@@ -137,7 +137,7 @@ export class GlobalEventService {
         }
 
         const workspaceFolderUri = workspace.workspaceFolders[0].uri;
-        const uri = workspaceFolderUri.with({ path: posix.join(workspaceFolderUri.path, "events", name + ".js") });
+        const uri = Uri.joinPath(workspaceFolderUri, "events", name + ".js");
 
         await workspace.fs.writeFile(
             uri,

--- a/src/services/ServerService.ts
+++ b/src/services/ServerService.ts
@@ -1,12 +1,12 @@
 import { ServerConfig } from "../models/ServerConfig";
 import { ServerDTO } from "../models/ServerDTO";
 import { UtilsService } from "./UtilsService";
-import { window } from "vscode";
+import { window, Uri } from "vscode";
 import { Server } from "../models/Server";
 
 export class ServerService {
-    private static PATH = UtilsService.getWorkspace() + '/.vscode';
-    private static FILE_SERVER_CONFIG = ServerService.PATH + '/servers.json';
+    private static PATH = Uri.joinPath(UtilsService.getWorkspace(), '.vscode').fsPath;
+    private static FILE_SERVER_CONFIG = Uri.joinPath(UtilsService.getWorkspace(), '.vscode', 'servers.json').fsPath;
 
     /**
      * Adiciona um novo servidor

--- a/src/services/UtilsService.ts
+++ b/src/services/UtilsService.ts
@@ -9,13 +9,14 @@ export class UtilsService {
     /**
      * Retorna o PATH do workspace
      */
-    public static getWorkspace() {
+    public static getWorkspace(): vscode.Uri {
         if (!vscode.workspace.workspaceFolders) {
-            vscode.window.showInformationMessage("Você não esta em um diretório /workspace.");
-            return require('os').homedir();
+            vscode.window.showInformationMessage("Você não esta em um diretório / workspace.");
+
+            throw "Obrigatório estar em um diretório / workspace";
         }
 
-        return vscode.workspace.workspaceFolders[0].uri.fsPath;
+        return vscode.workspace.workspaceFolders[0].uri;
     }
 
     public static getHost(server: ServerDTO): string {

--- a/src/views/DatasetView.ts
+++ b/src/views/DatasetView.ts
@@ -29,7 +29,7 @@ export class DatasetView {
     }
 
     private async getWebViewContent() {
-        const htmlPath = vscode.Uri.file(path.join(this.context.extensionPath, 'dist', 'views', 'dataset', 'dataset.html'));
+        const htmlPath = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'views', 'dataset', 'dataset.html');
         const runTemplate = compile(fs.readFileSync(htmlPath.with({ scheme: 'vscode-resource' }).fsPath));
 
         return runTemplate({

--- a/src/views/ServerView.ts
+++ b/src/views/ServerView.ts
@@ -34,7 +34,7 @@ export class ServerView {
     }
 
     private getWebViewContent() {
-        const htmlPath = vscode.Uri.file(path.join(this.context.extensionPath, 'dist', 'views', 'server', 'server.html'));
+        const htmlPath = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'views', 'server', 'server.html');
         const runTemplate = compile(fs.readFileSync(htmlPath.with({ scheme: 'vscode-resource' }).fsPath));
 
         return runTemplate({


### PR DESCRIPTION
As chamadas de `posix.join` foram alteradas para `vscode.Uri.joinPath` para manter consistência entre os SOs.

Além disso foi atualizada a versão mínima do motor do VSCode e algumas aplicadas algumas atualizações de segurança indicadas pelo Bot do GitHub.

Fix #19 