### PR TITLE
Corrige importação dos eventos de formulário

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Lista de atualizações da Extensão.
 
+## 1.19.6
+
+Corrige a criação do diretório de eventos ao importar um formulário.
+
+## 1.19.5
+
+Impede configurar parâmetros de consulta de Dataset antes da primeira execução.
+
 ## 1.19.4
 
 - Aumenta a versão do motor do VSCode;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.19.5",
+    "version": "1.19.6",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/src/services/FormService.ts
+++ b/src/services/FormService.ts
@@ -216,7 +216,7 @@ export class FormService {
      * Realiza a importação de um formulário específico
      */
      public static async import() {
-        if (!workspace.workspaceFolders) {
+        if (!workspace.workspaceFolders || !workspace.workspaceFolders[0]) {
             window.showInformationMessage("Você precisa estar em um diretório / workspace.");
             return;
         }
@@ -246,7 +246,8 @@ export class FormService {
             }
         }
 
-        folderUri = Uri.joinPath(workspace.workspaceFolders[0].uri, 'forms', "events");
+        folderUri = Uri.joinPath(folderUri, "events");
+
         const events = await FormService.getCustomizationEvents(server, form.documentId);
 
         for (let item of events) {
@@ -258,7 +259,7 @@ export class FormService {
      * Realiza a importação de vários formulários
      */
      public static async importMany() {
-        if (!workspace.workspaceFolders) {
+        if (!workspace.workspaceFolders || !workspace.workspaceFolders[0]) {
             window.showInformationMessage("Você precisa estar em um diretório / workspace.");
             return;
         }
@@ -271,21 +272,18 @@ export class FormService {
 
         const forms = await FormService.getOptionsSelected(server);
 
-        if(!forms) {
+        if (!forms) {
             return;
         }
 
+        const workspaceFolder = workspace.workspaceFolders[0];
+
         forms.map(async form => {
-            if(!form) {
+            if (!form) {
                 return;
             }
 
-            if (!workspace.workspaceFolders) {
-                window.showInformationMessage("Você precisa estar em um diretório / workspace.");
-                return;
-            }
-
-            let folderUri = Uri.joinPath(workspace.workspaceFolders[0].uri, 'forms', form.documentDescription);
+            let folderUri = Uri.joinPath(workspaceFolder.uri, 'forms', form.documentDescription);
 
             const fileNames = await FormService.getFileNames(server, form.documentId);
 
@@ -298,7 +296,8 @@ export class FormService {
                 }
             }
 
-            folderUri = Uri.joinPath(workspace.workspaceFolders[0].uri, 'forms', "events");
+            folderUri = Uri.joinPath(folderUri, "events");
+
             const events = await FormService.getCustomizationEvents(server, form.documentId);
 
             for (let item of events) {


### PR DESCRIPTION
O diretório `events` dos formulários estava sendo criada na raiz dos formulários ao invés de ser criada dentro do diretório do formulário importado.