### PR TITLE
Melhorias de simplificação de código

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Lista de atualizações da Extensão.
 
+## 1.22.0
+
+- Várias melhorias de refatoração do código para facilitar compreensão.
+- Não inicializa a Extensão caso o VS Code não esteja com Diretório, ou Workspace, aberto.
+- Mantém último servidor utilizado no topo da lista de seleção para agilizar importação/exportação de artefatos.
+
 ## 1.21.0
 
 Permite indicar o campo descritor ao exportar formulário.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "1.21.0",
+            "version": "1.22.0",
             "devDependencies": {
                 "@popperjs/core": "^2.11.6",
                 "@types/crypto-js": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -64,7 +64,8 @@ body.vscode-high-contrast:not(.vscode-high-contrast-light) .form-select {
 }
 
 .btn.disabled,
-.btn:disabled, fieldset:disabled .btn {
+.btn:disabled,
+fieldset:disabled .btn {
     color: inherit;
     pointer-events: none;
     background-color: inherit;
@@ -129,7 +130,8 @@ body.vscode-high-contrast:not(.vscode-high-contrast-light) .form-select {
     border: 1px solid var(--vscode-input-border, var(--bs-gray));
 }
 
-.table thead th, .table tbody td {
+.table thead th,
+.table tbody td {
     border-bottom: 1px solid var(--vscode-input-border, var(--bs-gray));
 }
 
@@ -143,7 +145,9 @@ div.dt-button-info h2 {
     background-color: var(--vscode-editor-background);
 }
 
-.table-bordered, .table-bordered td, .table-bordered th {
+.table-bordered,
+.table-bordered td,
+.table-bordered th {
     border: 1px solid var(--vscode-input-border, var(--bs-gray));
 }
 
@@ -163,7 +167,8 @@ div.dt-button-info h2 {
     color: var(--vscode-editor-foreground);
 }
 
-.modal-content, .tab-content {
+.modal-content,
+.tab-content {
     background-color: var(--vscode-editor-background);
     border: 1px solid var(--vscode-input-border, var(--bs-gray));
 }
@@ -189,7 +194,8 @@ div.dt-button-info h2 {
     border-bottom-color: transparent;
 }
 
-.nav-tabs .nav-link:focus, .nav-tabs .nav-link:hover {
+.nav-tabs .nav-link:focus,
+.nav-tabs .nav-link:hover {
     border-color: var(--vscode-input-border, var(--bs-gray)) var(--vscode-input-border, var(--bs-gray)) var(--vscode-input-border, var(--bs-gray));
 }
 

--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -5,7 +5,8 @@ body {
     font-size: var(--vscode-editor-font-size);
 }
 
-body.vscode-dark .form-select, body.vscode-high-contrast:not(.vscode-high-contrast-light) .form-select {
+body.vscode-dark .form-select,
+body.vscode-high-contrast:not(.vscode-high-contrast-light) .form-select {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e")
 }
 
@@ -13,14 +14,17 @@ body.vscode-dark .form-select, body.vscode-high-contrast:not(.vscode-high-contra
     color: var(--vscode-input-placeholderForeground);
 }
 
-.form-control, .form-select, .select2-container--bootstrap .select2-search--dropdown .select2-search__field {
+.form-control,
+.form-select,
+.select2-container--bootstrap .select2-search--dropdown .select2-search__field {
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
     border: 1px solid var(--vscode-input-border, var(--bs-gray));
     font-size: var(--vscode-editor-font-size);
 }
 
-.form-control:focus, .select2-container--bootstrap .select2-search--dropdown .select2-search__field {
+.form-control:focus,
+.select2-container--bootstrap .select2-search--dropdown .select2-search__field {
     background-color: var(--vscode-input-background);
     color: var(--vscode-input-foreground);
     border-color: var(--vscode-focusBorder);
@@ -33,8 +37,11 @@ body.vscode-dark .form-select, body.vscode-high-contrast:not(.vscode-high-contra
 }
 
 .btn-primary:hover,
-.btn-primary.focus, .btn-primary:focus,
-.btn-primary:not(:disabled):not(.disabled).active, .btn-primary:not(:disabled):not(.disabled):active, .show>.btn-primary.dropdown-toggle {
+.btn-primary.focus,
+.btn-primary:focus,
+.btn-primary:not(:disabled):not(.disabled).active,
+.btn-primary:not(:disabled):not(.disabled):active,
+.show>.btn-primary.dropdown-toggle {
     background-color: var(--vscode-button-hoverBackground, var(--bs-primary));
     border-color: var(--vscode-button-separator);
 }
@@ -46,14 +53,18 @@ body.vscode-dark .form-select, body.vscode-high-contrast:not(.vscode-high-contra
 }
 
 .btn-secondary:hover,
-.btn-secondary.focus, .btn-secondary:focus,
-.btn-secondary:not(:disabled):not(.disabled).active, .btn-secondary:not(:disabled):not(.disabled):active, .show>.btn-secondary.dropdown-toggle {
+.btn-secondary.focus,
+.btn-secondary:focus,
+.btn-secondary:not(:disabled):not(.disabled).active,
+.btn-secondary:not(:disabled):not(.disabled):active,
+.show>.btn-secondary.dropdown-toggle {
     border-color: var(--vscode-button-separator);
     color: var(--vscode-button-secondaryForeground);
     background-color: var(--vscode-button-hoverBackground, var(--bs-secondary));
 }
 
-.btn.disabled, .btn:disabled, fieldset:disabled .btn {
+.btn.disabled,
+.btn:disabled, fieldset:disabled .btn {
     color: inherit;
     pointer-events: none;
     background-color: inherit;
@@ -182,11 +193,33 @@ div.dt-button-info h2 {
     border-color: var(--vscode-input-border, var(--bs-gray)) var(--vscode-input-border, var(--bs-gray)) var(--vscode-input-border, var(--bs-gray));
 }
 
-table.dataTable thead>tr>th.sorting:before, table.dataTable thead>tr>th.sorting:after, table.dataTable thead>tr>th.sorting_asc:before, table.dataTable thead>tr>th.sorting_asc:after, table.dataTable thead>tr>th.sorting_desc:before, table.dataTable thead>tr>th.sorting_desc:after, table.dataTable thead>tr>th.sorting_asc_disabled:before, table.dataTable thead>tr>th.sorting_asc_disabled:after, table.dataTable thead>tr>th.sorting_desc_disabled:before, table.dataTable thead>tr>th.sorting_desc_disabled:after, table.dataTable thead>tr>td.sorting:before, table.dataTable thead>tr>td.sorting:after, table.dataTable thead>tr>td.sorting_asc:before, table.dataTable thead>tr>td.sorting_asc:after, table.dataTable thead>tr>td.sorting_desc:before, table.dataTable thead>tr>td.sorting_desc:after, table.dataTable thead>tr>td.sorting_asc_disabled:before, table.dataTable thead>tr>td.sorting_asc_disabled:after, table.dataTable thead>tr>td.sorting_desc_disabled:before, table.dataTable thead>tr>td.sorting_desc_disabled:after {
+table.dataTable thead>tr>th.sorting:before,
+table.dataTable thead>tr>th.sorting:after,
+table.dataTable thead>tr>th.sorting_asc:before,
+table.dataTable thead>tr>th.sorting_asc:after,
+table.dataTable thead>tr>th.sorting_desc:before,
+table.dataTable thead>tr>th.sorting_desc:after,
+table.dataTable thead>tr>th.sorting_asc_disabled:before,
+table.dataTable thead>tr>th.sorting_asc_disabled:after,
+table.dataTable thead>tr>th.sorting_desc_disabled:before,
+table.dataTable thead>tr>th.sorting_desc_disabled:after,
+table.dataTable thead>tr>td.sorting:before,
+table.dataTable thead>tr>td.sorting:after,
+table.dataTable thead>tr>td.sorting_asc:before,
+table.dataTable thead>tr>td.sorting_asc:after,
+table.dataTable thead>tr>td.sorting_desc:before,
+table.dataTable thead>tr>td.sorting_desc:after,
+table.dataTable thead>tr>td.sorting_asc_disabled:before,
+table.dataTable thead>tr>td.sorting_asc_disabled:after,
+table.dataTable thead>tr>td.sorting_desc_disabled:before,
+table.dataTable thead>tr>td.sorting_desc_disabled:after {
     opacity: 0.6;
 }
 
-table.dataTable thead>tr>th.sorting_asc:before, table.dataTable thead>tr>th.sorting_desc:after, table.dataTable thead>tr>td.sorting_asc:before, table.dataTable thead>tr>td.sorting_desc:after {
+table.dataTable thead>tr>th.sorting_asc:before,
+table.dataTable thead>tr>th.sorting_desc:after,
+table.dataTable thead>tr>td.sorting_asc:before,
+table.dataTable thead>tr>td.sorting_desc:after {
     opacity: 1;
 }
 

--- a/resources/views/dataset/dataset.css
+++ b/resources/views/dataset/dataset.css
@@ -14,7 +14,8 @@
     margin-right: 10px;
 }
 
-#tbResultDataset th, #tbResultDataset td {
+#tbResultDataset th,
+#tbResultDataset td {
     white-space: nowrap;
 }
 
@@ -60,7 +61,8 @@
     padding-left: 1.5rem;
 }
 
-#tabOrders .form-switch .form-check-input, #tabOrders .form-switch .form-check-label {
+#tabOrders .form-switch .form-check-input,
+#tabOrders .form-switch .form-check-label {
     cursor: pointer;
 }
 

--- a/resources/views/dataset/dataset.html
+++ b/resources/views/dataset/dataset.html
@@ -38,13 +38,19 @@
                     <div class="modal-body">
                         <ul class="nav nav-tabs">
                             <li class="nav-item">
-                                <a class="nav-link active" data-bs-toggle="tab" href="#tabConstraints" role="tab" aria-controls="tabConstraints" aria-selected="true">Constraints</a>
+                                <a class="nav-link active" data-bs-toggle="tab" href="#tabConstraints" role="tab" aria-controls="tabConstraints" aria-selected="true">
+                                    Constraints
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" data-bs-toggle="tab" href="#tabFields" role="tab" aria-controls="tabFields" aria-selected="true">Campos</a>
+                                <a class="nav-link" data-bs-toggle="tab" href="#tabFields" role="tab" aria-controls="tabFields" aria-selected="true">
+                                    Campos
+                                </a>
                             </li>
                             <li class="nav-item">
-                                <a class="nav-link" data-bs-toggle="tab" href="#tabOrders" role="tab" aria-controls="tabOrders" aria-selected="true">Ordem</a>
+                                <a class="nav-link" data-bs-toggle="tab" href="#tabOrders" role="tab" aria-controls="tabOrders" aria-selected="true">
+                                    Ordem
+                                </a>
                             </li>
                         </ul>
                         <div class="tab-content">
@@ -102,7 +108,9 @@
 
                         <div class="row">
                             <dic class="col-md-12">
-                                <button type="button" id="atualizaConsulta" class="btn btn-primary" data-bs-dismiss="modal" aria-label="Close">Atualizar Consulta</button>
+                                <button type="button" id="atualizaConsulta" class="btn btn-primary" data-bs-dismiss="modal" aria-label="Close">
+                                    Atualizar Consulta
+                                </button>
                             </dic>
                         </div>
                     </div>

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -10,7 +10,7 @@
             "    </div>",
             "</div>$0"
         ],
-        "description": "Cria um campo do tipo Texto."
+        "description": "Cria um campo do tipo text."
     },
 
     "fluig-input-textarea": {
@@ -24,7 +24,7 @@
             "    </div>",
             "</div>$0"
         ],
-        "description": "Cria um campo do tipo Texto."
+        "description": "Cria um campo do tipo textarea."
     },
 
     "fluig-input-zoom": {

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -305,7 +305,7 @@
             "        initWidgetElements: function () {",
             "            widgetElements.widget = this.DOM;",
             "            widgetElements.loading = FLUIGC.loading(window, {",
-            "                textMessage: \"Processando Dados. Favor aguardar!.\"",
+            "                textMessage: \"Processando Dados. Favor aguardar.\"",
             "            });",
             "        },",
             "",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -131,12 +131,6 @@ export function deactivate() { }
  * Cria um arquivo contendo um novo Dataset
  */
 async function createDataset() {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     let dataset: string = await vscode.window.showInputBox({
         prompt: "Qual o nome do Dataset (sem espaços e sem caracteres especiais)?",
         placeHolder: "ds_nome_dataset"
@@ -150,7 +144,7 @@ async function createDataset() {
         dataset += ".js";
     }
 
-    const datasetUri = vscode.Uri.joinPath(workspaceFolderUri, "datasets", dataset);
+    const datasetUri = vscode.Uri.joinPath(UtilsService.getWorkspaceUri(), "datasets", dataset);
 
     try {
         await vscode.workspace.fs.stat(datasetUri);
@@ -170,12 +164,6 @@ async function createDataset() {
  * Cria um arquivo contendo um novo Dataset
  */
 async function createMechanism() {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     let mechanism: string = await vscode.window.showInputBox({
         prompt: "Qual o nome do Mecanismo Customizado (sem espaços e sem caracteres especiais)?",
         placeHolder: "mecanismo_customizado"
@@ -189,7 +177,7 @@ async function createMechanism() {
         mechanism += ".js";
     }
 
-    const mechanismUri = vscode.Uri.joinPath(workspaceFolderUri, "mechanisms", mechanism);
+    const mechanismUri = vscode.Uri.joinPath(UtilsService.getWorkspaceUri(), "mechanisms", mechanism);
 
     try {
         await vscode.workspace.fs.stat(mechanismUri);
@@ -209,12 +197,6 @@ async function createMechanism() {
  * Cria um novo formulário
  */
 async function createForm() {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     let formName: string = await vscode.window.showInputBox({
         prompt: "Qual o nome do Formulário (sem espaços e sem caracteres especiais)?",
         placeHolder: "NomeFormulario"
@@ -226,7 +208,7 @@ async function createForm() {
 
     const formFileName = formName + ".html";
     const formUri = vscode.Uri.joinPath(
-        workspaceFolderUri,
+        UtilsService.getWorkspaceUri(),
         "forms",
         formName,
         formFileName
@@ -247,12 +229,6 @@ async function createForm() {
  * Cria um novo evento de formulário
  */
 async function createFormEvent(folderUri: vscode.Uri) {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     // Ativado pela Tecla de Atalho
     if (!folderUri) {
         if (!vscode.window.activeTextEditor) {
@@ -283,7 +259,7 @@ async function createFormEvent(folderUri: vscode.Uri) {
 
     const eventFilename = eventName + ".js";
     const eventUri = vscode.Uri.joinPath(
-        workspaceFolderUri,
+        UtilsService.getWorkspaceUri(),
         "forms",
         formName,
         'events',
@@ -308,12 +284,6 @@ async function createFormEvent(folderUri: vscode.Uri) {
  * Cria um novo evento Global
  */
 async function createGlobalEvent(folderUri: vscode.Uri) {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     const eventName: string = await vscode.window.showQuickPick(
         TemplateService.globalEventsNames,
         {
@@ -328,7 +298,7 @@ async function createGlobalEvent(folderUri: vscode.Uri) {
 
     const eventFilename = eventName + ".js";
     const eventUri = vscode.Uri.joinPath(
-        workspaceFolderUri,
+        UtilsService.getWorkspaceUri(),
         "events",
         eventFilename
     );
@@ -351,12 +321,6 @@ async function createGlobalEvent(folderUri: vscode.Uri) {
  * Cria um novo evento de Processo
  */
 async function createWorkflowEvent(folderUri: vscode.Uri) {
-    const workspaceFolderUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceFolderUri) {
-        return;
-    }
-
     // Ativado pelo Atalho
     if (!folderUri) {
         if (!vscode.window.activeTextEditor) {
@@ -407,7 +371,7 @@ async function createWorkflowEvent(folderUri: vscode.Uri) {
 
     const eventFilename = `${processName}.${eventName}.js`;
     const eventUri = vscode.Uri.joinPath(
-        workspaceFolderUri,
+        UtilsService.getWorkspaceUri(),
         "workflow",
         "scripts",
         eventFilename
@@ -434,10 +398,6 @@ async function createWorkflowEvent(folderUri: vscode.Uri) {
  */
 function installDeclarationLibrary() {
     const workspaceUri = UtilsService.getWorkspaceUri();
-
-    if (!workspaceUri) {
-        return;
-    }
 
     const axiosConfig: AxiosRequestConfig = {
         responseType: "stream"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,68 +27,25 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newGlobalEvent", createGlobalEvent));
     context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newMechanism", createMechanism));
 
-
     // Servidores
 
     const serverItemProvider = new ServerItemProvider(context);
     vscode.window.registerTreeDataProvider("fluiggers-fluig-vscode-extension.servers", serverItemProvider);
 
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.addServer",
-        () => serverItemProvider.add()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.refreshServer",
-        () => serverItemProvider.refresh()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.editServer",
-        (serverItem: ServerItem) => serverItemProvider.update(serverItem)
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.deleteServer",
-        (serverItem: ServerItem) => serverItemProvider.delete(serverItem)
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.datasetView",
-        (datasetItem: DatasetItem) => serverItemProvider.datasetView(datasetItem)
-    ));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.addServer", serverItemProvider.add));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.refreshServer", serverItemProvider.refresh));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.editServer", serverItemProvider.update));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.deleteServer", serverItemProvider.delete));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.datasetView", serverItemProvider.datasetView));
 
     // Importação de artefatos
 
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importDataset",
-        () => DatasetService.import()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importManyDataset",
-        () => DatasetService.importMany()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importForm",
-        () => FormService.import()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importManyForm",
-        () => FormService.importMany()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importGlobalEvent",
-        () => GlobalEventService.import()
-    ));
-
-    context.subscriptions.push(vscode.commands.registerCommand(
-        "fluiggers-fluig-vscode-extension.importManyGlobalEvent",
-        () => GlobalEventService.importMany()
-    ));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importDataset", DatasetService.import));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyDataset", DatasetService.importMany));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importForm", FormService.import));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyForm", FormService.importMany));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importGlobalEvent", GlobalEventService.import));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyGlobalEvent", GlobalEventService.importMany));
 
     // Exportação de artefatos
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,150 +45,113 @@ export function activate(context: vscode.ExtensionContext) {
     EVENTS_NAMES.WORKFLOW = getTemplatesNameFromPath(EXTENSION_PATHS.WORKFLOW_EVENTS);
     EVENTS_NAMES.GLOBAL = getTemplatesNameFromPath(EXTENSION_PATHS.GLOBAL_EVENTS);
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newDataset", createDataset)
-    );
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.installDeclarationLibrary", installDeclarationLibrary));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newForm", createForm)
-    );
+    // Criação de artefatos
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newFormEvent", createFormEvent)
-    );
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newDataset", createDataset));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newForm", createForm));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newFormEvent", createFormEvent));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newWorkflowEvent", createWorkflowEvent));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newGlobalEvent", createGlobalEvent));
+    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newMechanism", createMechanism));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newWorkflowEvent", createWorkflowEvent)
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newGlobalEvent", createGlobalEvent)
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newMechanism", createMechanism)
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.installDeclarationLibrary", installDeclarationLibrary)
-    );
 
     // Servidores
+
     const serverItemProvider = new ServerItemProvider(context);
     vscode.window.registerTreeDataProvider("fluiggers-fluig-vscode-extension.servers", serverItemProvider);
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.addServer",
-            () => serverItemProvider.add()
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.addServer",
+        () => serverItemProvider.add()
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.refreshServer",
-            () => serverItemProvider.refresh()
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.refreshServer",
+        () => serverItemProvider.refresh()
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.editServer",
-            (serverItem: ServerItem) => serverItemProvider.update(serverItem)
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.editServer",
+        (serverItem: ServerItem) => serverItemProvider.update(serverItem)
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.deleteServer",
-            (serverItem: ServerItem) => serverItemProvider.delete(serverItem)
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.deleteServer",
+        (serverItem: ServerItem) => serverItemProvider.delete(serverItem)
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.datasetView",
-            (datasetItem: DatasetItem) => serverItemProvider.datasetView(datasetItem)
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.datasetView",
+        (datasetItem: DatasetItem) => serverItemProvider.datasetView(datasetItem)
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.importDataset",
-            () => DatasetService.import()
-        )
-    );
+    // Importação de artefatos
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.importManyDataset",
-            () => DatasetService.importMany()
-        )
-    );
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importDataset",
+        () => DatasetService.import()
+    ));
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.exportDataset",
-            function (fileUri: vscode.Uri) {
-                // Ativado pelo Atalho
-                if (!fileUri) {
-                    if (!vscode.window.activeTextEditor) {
-                        vscode.window.showErrorMessage("Não há editor de texto ativo com Dataset");
-                        return;
-                    }
-                    fileUri = vscode.window.activeTextEditor.document.uri;
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyDataset",
+        () => DatasetService.importMany()
+    ));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importForm",
+        () => FormService.import()
+    ));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyForm",
+        () => FormService.importMany()
+    ));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importGlobalEvent",
+        () => GlobalEventService.import()
+    ));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyGlobalEvent",
+        () => GlobalEventService.importMany()
+    ));
+
+    // Exportação de artefatos
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.exportDataset",
+        function (fileUri: vscode.Uri) {
+            // Ativado pela Tecla de Atalho
+            if (!fileUri) {
+                if (!vscode.window.activeTextEditor) {
+                    vscode.window.showErrorMessage("Não há editor de texto ativo com Dataset");
+                    return;
                 }
-
-                DatasetService.export(fileUri);
+                fileUri = vscode.window.activeTextEditor.document.uri;
             }
-        )
-    );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.exportForm",
-            function (fileUri: vscode.Uri) {
-                // Ativado pelo Atalho
-                if (!fileUri) {
-                    if (!vscode.window.activeTextEditor) {
-                        vscode.window.showErrorMessage("Não há editor de texto ativo com Formulário");
-                        return;
-                    }
-                    fileUri = vscode.window.activeTextEditor.document.uri;
+            DatasetService.export(fileUri);
+        }
+    ));
+
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.exportForm",
+        function (fileUri: vscode.Uri) {
+            // Ativado pela Tecla Atalho
+            if (!fileUri) {
+                if (!vscode.window.activeTextEditor) {
+                    vscode.window.showErrorMessage("Não há editor de texto ativo com Formulário");
+                    return;
                 }
-
-                FormService.export(fileUri);
+                fileUri = vscode.window.activeTextEditor.document.uri;
             }
-        )
-    );
 
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.importForm",
-            () => FormService.import()
-        )
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-                  "fluiggers-fluig-vscode-extension.importManyForm",
-            () => FormService.importMany()
-        )
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.importGlobalEvent",
-            () => GlobalEventService.import()
-        )
-    );
-
-    context.subscriptions.push(
-        vscode.commands.registerCommand(
-            "fluiggers-fluig-vscode-extension.importManyGlobalEvent",
-            () => GlobalEventService.importMany()
-        )
-    );
+            FormService.export(fileUri);
+        }
+    ));
 }
 
 export function deactivate() { }
@@ -339,7 +302,7 @@ async function createFormEvent(folderUri: vscode.Uri) {
         return;
     }
 
-    // Ativado pelo Atalho
+    // Ativado pela Tecla de Atalho
     if (!folderUri) {
         if (!vscode.window.activeTextEditor) {
             vscode.window.showErrorMessage("Não há editor de texto ativo com Dataset");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,11 +32,26 @@ export function activate(context: vscode.ExtensionContext) {
     const serverItemProvider = new ServerItemProvider(context);
     vscode.window.registerTreeDataProvider("fluiggers-fluig-vscode-extension.servers", serverItemProvider);
 
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.addServer", serverItemProvider.add));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.refreshServer", serverItemProvider.refresh));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.editServer", serverItemProvider.update));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.deleteServer", serverItemProvider.delete));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.datasetView", serverItemProvider.datasetView));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.addServer",
+        () => serverItemProvider.add()
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.refreshServer",
+        () => serverItemProvider.refresh()
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.editServer",
+        (serverItem: ServerItem) => serverItemProvider.update(serverItem)
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.deleteServer",
+        (serverItem: ServerItem) => serverItemProvider.delete(serverItem)
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.datasetView",
+        (datasetItem: DatasetItem) => serverItemProvider.datasetView(datasetItem)
+    ));
 
     // Importação de artefatos
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() { }
 
 /**
- * Cria um arquivo contendo um novo Dataset
+ * Cria um Dataset
  */
 async function createDataset() {
     let dataset: string = await vscode.window.showInputBox({
@@ -118,7 +118,7 @@ async function createDataset() {
 }
 
 /**
- * Cria um arquivo contendo um novo Dataset
+ * Cria um arquivo contendo um novo Mecanismo customizado
  */
 async function createMechanism() {
     let mechanism: string = await vscode.window.showInputBox({
@@ -140,7 +140,7 @@ async function createMechanism() {
         await vscode.workspace.fs.stat(mechanismUri);
         return vscode.window.showTextDocument(mechanismUri);
     } catch (err) {
-        console.error(err);
+
     }
 
     await vscode.workspace.fs.writeFile(
@@ -151,7 +151,7 @@ async function createMechanism() {
 }
 
 /**
- * Cria um novo formulário
+ * Cria um Formulário
  */
 async function createForm() {
     let formName: string = await vscode.window.showInputBox({
@@ -175,7 +175,7 @@ async function createForm() {
         await vscode.workspace.fs.stat(formUri);
         return vscode.window.showTextDocument(formUri);
     } catch (err) {
-        console.log(err);
+
     }
 
     await vscode.workspace.fs.writeFile(formUri, readFileSync(vscode.Uri.joinPath(TemplateService.templatesUri, 'form.txt').fsPath));
@@ -183,7 +183,7 @@ async function createForm() {
 }
 
 /**
- * Cria um novo evento de formulário
+ * Cria um Evento de Formulário
  */
 async function createFormEvent(folderUri: vscode.Uri) {
     // Ativado pela Tecla de Atalho
@@ -202,8 +202,10 @@ async function createFormEvent(folderUri: vscode.Uri) {
 
     const formName: string = folderUri.path.replace(/.*\/forms\/([^/]+).*/, "$1");
 
-    const eventName: string = await vscode.window.showQuickPick(
-        TemplateService.formEventsNames,
+    const newFunctionOption = 'Nova Função';
+
+    let eventName: string = await vscode.window.showQuickPick(
+        TemplateService.formEventsNames.concat(newFunctionOption),
         {
             canPickMany: false,
             placeHolder: "Selecione o Evento"
@@ -212,6 +214,21 @@ async function createFormEvent(folderUri: vscode.Uri) {
 
     if (!eventName) {
         return;
+    }
+
+    let isNewFunction = false;
+
+    if (eventName == newFunctionOption) {
+        eventName = await vscode.window.showInputBox({
+            prompt: "Qual o nome da Nova Função (sem espaços e sem caracteres especiais)?",
+            placeHolder: "nomeFuncao"
+        }) || "";
+
+        if (!eventName) {
+            return;
+        }
+
+        isNewFunction = true;
     }
 
     const eventFilename = eventName + ".js";
@@ -232,13 +249,16 @@ async function createFormEvent(folderUri: vscode.Uri) {
 
     await vscode.workspace.fs.writeFile(
         eventUri,
-        readFileSync(vscode.Uri.joinPath(TemplateService.formEventsUri, `${eventName}.txt`).fsPath)
+        isNewFunction
+            ? Buffer.from(createEmptyFunction(eventName), "utf-8")
+            : readFileSync(vscode.Uri.joinPath(TemplateService.formEventsUri, `${eventName}.txt`).fsPath)
     );
+
     vscode.window.showTextDocument(eventUri);
 }
 
 /**
- * Cria um novo evento Global
+ * Cria um Evento Global
  */
 async function createGlobalEvent(folderUri: vscode.Uri) {
     const eventName: string = await vscode.window.showQuickPick(
@@ -275,7 +295,7 @@ async function createGlobalEvent(folderUri: vscode.Uri) {
 }
 
 /**
- * Cria um novo evento de Processo
+ * Cria um Evento de Processo
  */
 async function createWorkflowEvent(folderUri: vscode.Uri) {
     // Ativado pelo Atalho

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,16 +16,37 @@ export function activate(context: vscode.ExtensionContext) {
     // Carrega os templates de criação de artefatos
     TemplateService.init(context);
 
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.installDeclarationLibrary", installDeclarationLibrary));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.installDeclarationLibrary",
+        installDeclarationLibrary
+    ));
 
     // Criação de artefatos
 
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newDataset", createDataset));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newForm", createForm));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newFormEvent", createFormEvent));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newWorkflowEvent", createWorkflowEvent));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newGlobalEvent", createGlobalEvent));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.newMechanism", createMechanism));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newDataset",
+        createDataset
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newForm",
+        createForm
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newFormEvent",
+        createFormEvent
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newWorkflowEvent",
+        createWorkflowEvent
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newGlobalEvent",
+        createGlobalEvent
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.newMechanism",
+        createMechanism
+    ));
 
     // Servidores
 
@@ -55,12 +76,30 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Importação de artefatos
 
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importDataset", DatasetService.import));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyDataset", DatasetService.importMany));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importForm", FormService.import));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyForm", FormService.importMany));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importGlobalEvent", GlobalEventService.import));
-    context.subscriptions.push(vscode.commands.registerCommand("fluiggers-fluig-vscode-extension.importManyGlobalEvent", GlobalEventService.importMany));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importDataset",
+        DatasetService.import
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyDataset",
+        DatasetService.importMany
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importForm",
+        FormService.import
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyForm",
+        FormService.importMany
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importGlobalEvent",
+        GlobalEventService.import
+    ));
+    context.subscriptions.push(vscode.commands.registerCommand(
+        "fluiggers-fluig-vscode-extension.importManyGlobalEvent",
+        GlobalEventService.importMany
+    ));
 
     // Exportação de artefatos
 
@@ -193,7 +232,10 @@ async function createForm() {
 
     }
 
-    await vscode.workspace.fs.writeFile(formUri, readFileSync(vscode.Uri.joinPath(TemplateService.templatesUri, 'form.txt').fsPath));
+    await vscode.workspace.fs.writeFile(
+        formUri,
+        readFileSync(vscode.Uri.joinPath(TemplateService.templatesUri, 'form.txt').fsPath)
+    );
     vscode.window.showTextDocument(formUri);
 }
 
@@ -396,8 +438,14 @@ function installDeclarationLibrary() {
     };
 
     Promise.all([
-        axios.get("https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/jsconfig.json", axiosConfig),
-        axios.get("https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/fluig.d.ts", axiosConfig)
+        axios.get(
+            "https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/jsconfig.json",
+            axiosConfig
+        ),
+        axios.get(
+            "https://raw.githubusercontent.com/fluiggers/fluig-declaration-type/master/fluig.d.ts",
+            axiosConfig
+        )
     ])
     .then(function ([jsConfig, fluigDeclarations]) {
         jsConfig.data.pipe(createWriteStream(vscode.Uri.joinPath(workspaceUri, "jsconfig.json").fsPath));

--- a/src/models/ServerConfig.ts
+++ b/src/models/ServerConfig.ts
@@ -2,7 +2,5 @@ import { ServerDTO } from "./ServerDTO";
 
 export interface ServerConfig {
     version: String,
-    permissions: undefined,
-    connectedServer: ServerDTO | undefined,
     configurations: ServerDTO[]
 }

--- a/src/services/DatasetService.ts
+++ b/src/services/DatasetService.ts
@@ -73,27 +73,21 @@ export class DatasetService {
             order: {item: order}
         };
 
-        const dataset = await soap.createClientAsync(uri, { handleNilAsNull: true })
+        const dataset = await soap.createClientAsync(uri)
             .then(client => client.getDatasetAsync(params))
             .then(response => response[0].dataset);
 
         const columns = Array.isArray(dataset.columns) ? dataset.columns : [dataset.columns];
 
         const mountValue = (item: any) => {
-            let valueObj: any = {};
+            const valueObj: any = {};
+            const values = Array.isArray(item.value) ? item.value : [item.value];
 
-            for(let index = 0; index < columns.length; index++) {
-                const column = columns[index];
-
-                let value = Array.isArray(item.value) ? item.value[index] : item.value;
-
-                if (value !== null && value['$value'] !== undefined) {
-                    value = value['$value'];
-                } else {
-                    value = "";
-                }
-
-                valueObj[column] = value;
+            for (let index = 0; index < columns.length; index++) {
+                valueObj[columns[index]] = (values[index] !== undefined && values[index]['$value'] !== undefined)
+                    ? values[index]['$value']
+                    : ""
+                ;
             }
 
             return valueObj;
@@ -102,10 +96,8 @@ export class DatasetService {
         const retValues = dataset.values;
         let values = [];
 
-        if(Array.isArray(retValues)) {
-            values = retValues.map((item: any) => {
-                return mountValue(item);
-            });
+        if (Array.isArray(retValues)) {
+            values = retValues.map(item => mountValue(item));
         } else if(retValues !== undefined && retValues !== null) {
             const item = retValues;
             values.push(mountValue(item));

--- a/src/services/ServerService.ts
+++ b/src/services/ServerService.ts
@@ -5,8 +5,8 @@ import { window, Uri } from "vscode";
 import { Server } from "../models/Server";
 
 export class ServerService {
-    private static PATH = Uri.joinPath(UtilsService.getWorkspace(), '.vscode').fsPath;
-    private static FILE_SERVER_CONFIG = Uri.joinPath(UtilsService.getWorkspace(), '.vscode', 'servers.json').fsPath;
+    private static PATH = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode').fsPath;
+    private static FILE_SERVER_CONFIG = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode', 'servers.json').fsPath;
 
     /**
      * Adiciona um novo servidor

--- a/src/services/ServerService.ts
+++ b/src/services/ServerService.ts
@@ -1,3 +1,4 @@
+import { QuickPickItem } from "vscode";
 import { ServerConfig } from "../models/ServerConfig";
 import { ServerDTO } from "../models/ServerDTO";
 import { UtilsService } from "./UtilsService";
@@ -7,6 +8,7 @@ import { Server } from "../models/Server";
 export class ServerService {
     private static PATH = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode').fsPath;
     private static FILE_SERVER_CONFIG = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode', 'servers.json').fsPath;
+    private static SELECTED_SERVER: string = "";
 
     /**
      * Adiciona um novo servidor
@@ -87,8 +89,7 @@ export class ServerService {
     }
 
     public static async getSelect() {
-        const serversConfig = ServerService.getServerConfig();
-        const servers = serversConfig.configurations.map(server => ({ label: server.name }));
+        const servers = ServerService.getServersLabels();
 
         const result = await window.showQuickPick(servers, {
             placeHolder: "Selecione o servidor",
@@ -98,7 +99,31 @@ export class ServerService {
             return;
         }
 
+        ServerService.SELECTED_SERVER = result.label;
+
         return new Server(ServerService.findByName(result.label));
+    }
+
+    private static getServersLabels() {
+        const serversConfig = ServerService.getServerConfig();
+        const serversLabels: QuickPickItem[] = [];
+        let hasSelectedServer = false;
+
+        for (let i = 0; i < serversConfig.configurations.length; ++i) {
+            const serverName = serversConfig.configurations[i].name;
+
+            if (serverName === ServerService.SELECTED_SERVER) {
+                hasSelectedServer = true;
+                continue;
+            }
+            serversLabels.push({ label: serverName });
+        }
+
+        if (hasSelectedServer) {
+            serversLabels.unshift({ label: ServerService.SELECTED_SERVER});
+        }
+
+        return serversLabels;
     }
 
     /**
@@ -121,8 +146,6 @@ export class ServerService {
         const fs = require('fs');
         const serverConfig: ServerConfig = {
             version: "0.0.1",
-            permissions: undefined,
-            connectedServer: undefined,
             configurations: []
         };
 

--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -1,0 +1,35 @@
+import * as vscode from 'vscode';
+import { glob } from "glob";
+import { basename } from "path";
+
+export class TemplateService {
+    public static templatesUri: vscode.Uri;
+    public static formEventsUri: vscode.Uri;
+    public static workflowEventsUri: vscode.Uri;
+    public static globalEventsUri: vscode.Uri;
+
+    public static formEventsNames: string[];
+    public static workflowEventsNames: string[];
+    public static globalEventsNames: string[];
+
+    public static init(context: vscode.ExtensionContext): void {
+        TemplateService.templatesUri = vscode.Uri.joinPath(context.extensionUri, 'dist', 'templates');
+        TemplateService.formEventsUri = vscode.Uri.joinPath(TemplateService.templatesUri, 'formEvents');
+        TemplateService.workflowEventsUri = vscode.Uri.joinPath(TemplateService.templatesUri, 'workflowEvents');
+        TemplateService.globalEventsUri = vscode.Uri.joinPath(TemplateService.templatesUri, 'globalEvents');
+        TemplateService.formEventsNames = TemplateService.getTemplatesNameFromPath(TemplateService.formEventsUri);
+        TemplateService.workflowEventsNames = TemplateService.getTemplatesNameFromPath(TemplateService.workflowEventsUri);
+        TemplateService.globalEventsNames = TemplateService.getTemplatesNameFromPath(TemplateService.globalEventsUri);
+    }
+
+    /**
+     * Pega o nome dos templates de determinado diretório
+     *
+     * @param path Diretório onde estão os templates
+     * @returns Nome dos arquivos sem a extensão
+     */
+    private static getTemplatesNameFromPath(templatesUri: vscode.Uri): string[] {
+        return glob.sync(vscode.Uri.joinPath(templatesUri, '*.txt').fsPath)
+            .map(filename => basename(filename, '.txt'));
+    }
+}

--- a/src/services/UtilsService.ts
+++ b/src/services/UtilsService.ts
@@ -9,11 +9,10 @@ export class UtilsService {
     /**
      * Retorna o PATH do workspace
      */
-    public static getWorkspace(): vscode.Uri {
+    public static getWorkspaceUri(): vscode.Uri|null {
         if (!vscode.workspace.workspaceFolders) {
-            vscode.window.showInformationMessage("Você não esta em um diretório / workspace.");
-
-            throw "Obrigatório estar em um diretório / workspace";
+            vscode.window.showErrorMessage("Você não está em um Diretório / Workspace.");
+            return null;
         }
 
         return vscode.workspace.workspaceFolders[0].uri;

--- a/src/services/UtilsService.ts
+++ b/src/services/UtilsService.ts
@@ -9,12 +9,10 @@ export class UtilsService {
     /**
      * Retorna o PATH do workspace
      */
-    public static getWorkspaceUri(): vscode.Uri|null {
+    public static getWorkspaceUri(): vscode.Uri {
         if (!vscode.workspace.workspaceFolders) {
-            vscode.window.showErrorMessage("Você não está em um Diretório / Workspace.");
-            return null;
+            throw "É necessário estar em Workspace / Diretório.";
         }
-
         return vscode.workspace.workspaceFolders[0].uri;
     }
 


### PR DESCRIPTION
Organiza um pouco o código para facilitar manutenção e melhorias.

Remove a conferência constante de estar em um diretório simplesmente bloqueando a Extensão de inicializar caso não esteja em diretório.

Mantém o último servidor utilizado como primeiro da lista de seleção de servidores para agilizar ao importar/exportar artefatos constantemente.