### PR TITLE
Correção de tipo de mensagem em falha ao exportar dataset

### DIFF
--- a/src/services/DatasetService.ts
+++ b/src/services/DatasetService.ts
@@ -335,7 +335,7 @@ export class DatasetService {
         if (result.content === 'OK') {
             window.showInformationMessage("Dataset " + datasetId + " exportado com sucesso!");
         } else {
-            window.showInformationMessage("Falha ao exportar o dataset " + datasetId + "!\n" + result.message.message);
+			window.showErrorMessage(`Falha ao exportar o dataset ${datasetId}!\n${result.message.message}`);
         }
     }
 


### PR DESCRIPTION
A antiga mensagem de erro não possuía o tipo correto de ícone
![WhatsApp Image 2024-08-30 at 16 39 43_4a329151](https://github.com/user-attachments/assets/adf440ba-542c-4842-9888-01b5efae9cd1)
