### PR TITLE
Adiciona feature de atualização de datasets em pastas já criadas

### DIFF
--- a/src/services/DatasetService.ts
+++ b/src/services/DatasetService.ts
@@ -183,16 +183,42 @@ export class DatasetService {
             return;
         }
 
-        const dataset:any = await DatasetService.getOptionSelected(server);
+        const dataset: any = await DatasetService.getOptionSelected(server);
 
         if (!dataset) {
             return;
         }
 
-        DatasetService.saveFile(
-            dataset.datasetPK.datasetId,
-            dataset.datasetImpl
+        const datasetId = dataset.datasetPK.datasetId;
+        const workspaceUri = UtilsService.getWorkspaceUri();
+
+        // Busca por arquivos de dataset com o mesmo nome
+        const existingFiles = glob.sync(
+            workspaceUri.fsPath + "/**/" + datasetId + ".js",
+            { nodir: true }
         );
+
+        if (existingFiles.length === 1) {
+            // Se achar apenas um arquivo, ele vai ser atualizado com o código do dataset importado, mantendo o caminho que o dataset que já existe
+            const targetPath = existingFiles[0];
+
+            // Escreve no arquivo existente
+            await workspace.fs.writeFile(
+                Uri.file(targetPath),
+                Buffer.from(dataset.datasetImpl, "utf-8")
+            );
+
+            window.showTextDocument(Uri.file(targetPath));
+            window.showInformationMessage(
+                `Dataset ${datasetId} atualizado com sucesso!`
+            );
+        } else {
+            // Se não achar nenhum arquivo ou achar mais de um, vai ser salvo na pasta padrão ./datasets
+            DatasetService.saveFile(datasetId, dataset.datasetImpl);
+            window.showInformationMessage(
+                `Dataset ${datasetId} importado com sucesso!`
+            );
+        }
     }
 
     /**
@@ -211,40 +237,63 @@ export class DatasetService {
             return;
         }
 
+        const workspaceUri = UtilsService.getWorkspaceUri();
 
         const results = await window.withProgress(
             {
                 location: ProgressLocation.Notification,
                 title: "Importando Datasets.",
-                cancellable: false
+                cancellable: false,
             },
-            progress => {
+            (progress) => {
                 const increment = 100 / datasets.length;
                 let current = 0;
 
                 progress.report({ increment: 0 });
 
-                return Promise.all(datasets.map(async (item: any) => {
-                    const dataset = await item;
-                    DatasetService.saveFile(
-                        dataset.datasetPK.datasetId,
-                        dataset.datasetImpl,
-                        false
-                    );
-                    current += increment;
-                    progress.report({ increment: current });
-                    return true;
-                }));
+                return Promise.all(
+                    datasets.map(async (item: any) => {
+                        const dataset = await item;
+                        const datasetId = dataset.datasetPK.datasetId;
+
+                        // Busca por arquivos de dataset com o mesmo nome
+                        const existingFiles = glob.sync(
+                            workspaceUri.fsPath + "/**/" + datasetId + ".js",
+                            { nodir: true }
+                        );
+
+                        if (existingFiles.length === 1) {
+                            // Se achar apenas um arquivo, ele vai ser atualizado com o código do dataset importado, mantendo o caminho que o dataset que já existe
+                            await workspace.fs.writeFile(
+                                Uri.file(existingFiles[0]),
+                                Buffer.from(dataset.datasetImpl, "utf-8")
+                            );
+                        } else {
+                            // Se não achar nenhum arquivo ou achar mais de um, vai ser salvo na pasta padrão ./datasets
+                            DatasetService.saveFile(
+                                datasetId,
+                                dataset.datasetImpl,
+                                false
+                            );
+                        }
+
+                        current += increment;
+                        progress.report({ increment: current });
+                        return true;
+                    })
+                );
             }
         );
 
-        window.showInformationMessage(`${results.length} datasets foram importados.`);
+        window.showInformationMessage(
+            `${results.length} datasets foram importados.`
+        );
     }
 
     /**
      * Criar ou atualizar dataset no servidor
      */
-     public static async export(fileUri: Uri) {
+    public static async export(fileUri: Uri) {
         const server = await ServerService.getSelect();
 
         if (!server) {


### PR DESCRIPTION
Descreva a melhoria
Atualmente, ao importar datasets do Fluig que estão organizados em subpastas dentro da pasta datasets (ex: datasets/financeiro/ds_contas_pagar), eles são importados para a raiz da pasta datasets no ambiente de destino. A sugestão é que o processo de importação detecte a estrutura de subpastas original e a replique no ambiente de destino. Assim, um dataset localizado em datasets/financeiro/ds_contas_pagar seria importado mantendo sua localização na subpasta datasets/financeiro/

Ganhos

Manutenção da Organização: Preserva a estrutura lógica de pastas definida no ambiente de origem, facilitando a localização e gestão dos datasets.

Redução de Trabalho Manual: Evita a necessidade de mover manualmente os datasets para suas respectivas subpastas após a importação.

Prevenção de Conflitos: Ajuda a evitar potenciais conflitos de nomes se datasets com o mesmo nome existirem em subpastas diferentes na origem

resolves issue https://github.com/fluiggers/fluig-vscode-extension/issues/56