### PR TITLE
Corrige duplicação de arquivos de eventos ao exportar formulário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "2.3.0",
+            "version": "2.3.1",
             "devDependencies": {
                 "@popperjs/core": "^2.11.8",
                 "@types/glob": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/src/services/FormService.ts
+++ b/src/services/FormService.ts
@@ -298,8 +298,12 @@ export class FormService {
         }
 
         const formFolder = Uri.joinPath(UtilsService.getWorkspaceUri(), 'forms', formFolderName).fsPath;
+        const isEvent = /[/\\]events$/;
 
-        for (let attachmentPath of glob.sync(formFolder + "/**/*.*", {nodir: true, ignore: formFolder + "/events/**/*.*"})) {
+        for (let attachmentPath of glob.sync(`${formFolder}/**/*.*`, {
+            nodir: true,
+            ignore: { ignored: (path => isEvent.test(path.parentPath) ) }
+        })) {
             const pathParsed = parse(attachmentPath);
 
             const attachment: AttachmentDTO = {


### PR DESCRIPTION
A biblioteca glob não estava ignorando os arquivos de eventos de formulário ao exportar os attachments do formulário, assim os arquivos de eventos estava sendo exportados como parte do formulário, além de ir como evento de formulário.