### PR TITLE
Informa erro ao não encontrar widget na importação

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Lista de atualizações da Extensão.
 
+## 2.4.1
+
+Informa erro ao não encontrar o arquivo .war da widget na importação de widget.
+
 ## 2.4.0
 
 Efetua correções tipográficas e adiciona os seguintes snippets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "devDependencies": {
                 "@popperjs/core": "^2.11.8",
                 "@types/glob": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/src/services/WidgetService.ts
+++ b/src/services/WidgetService.ts
@@ -424,6 +424,12 @@ export class WidgetService {
                 headers: { 'Cookie': await LoginService.loginAndGetCookies(server) }
             }
         )
-        .then(r => r.arrayBuffer())
+        .then(async (r) => {
+            if (r.status !== 200) {
+                const message = await r.text();
+                throw `${widgetFileName}: ${message}`;
+            }
+            return r.arrayBuffer();
+        })
     }
 }


### PR DESCRIPTION
A extensão confiava que ao chegar na etapa de download da widget o arquivo .war sempre estaria disponível, porém em algumas situações ele pode não ser encontrado. Por isso é importante disparar o erro informando a falha na importação.