### PR TITLE
Corrige snippet e remove mensagem de erro que deixa dúvidas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Lista de atualizações da Extensão.
 
+## 2.4.2
+
+- Corrige o snippet fluig-pai-filho-nobuttons;
+- Remove a mensagem "Para Fluig anterior ao 1.8.2 utilize a versão antiga da Extensão." nos erros de exportar Widget;
+
 ## 2.4.1
 
 Informa erro ao não encontrar o arquivo .war da widget na importação de widget.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "2.4.1",
+            "version": "2.4.2",
             "devDependencies": {
                 "@popperjs/core": "^2.11.8",
                 "@types/glob": "^8.1.0",
@@ -1266,9 +1266,9 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-            "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -292,7 +292,7 @@
         "scope": "html",
         "prefix": "fluig-pai-filho-nobuttons",
         "body": [
-            "<table id=\"tbl${1:NomeTabela}\" tablename=\"tbl${1:NomeTabela}\" class=\"table table-condensed table-striped\">",
+            "<table id=\"tbl${1:NomeTabela}\" tablename=\"tbl${1:NomeTabela}\" noaddbutton=\"true\" nodeletebutton=\"true\" class=\"table table-condensed table-striped\">",
             "    <thead>",
             "        <tr>",
             "            <th>$0</th>",

--- a/src/services/WidgetService.ts
+++ b/src/services/WidgetService.ts
@@ -167,7 +167,7 @@ export class WidgetService {
                     }
                 ).then(r => {
                     if (!r.ok) {
-                        throw new Error(`${r.status} - ${r.statusText}. Para Fluig anterior ao 1.8.2 utilize a versão antiga da Extensão.`);
+                        throw new Error(`${r.status} - ${r.statusText}.`);
                     }
 
                     return r.json();


### PR DESCRIPTION
O snippet fluig-pai-filho-nobuttons não estava removendo os botões padrões da tabela Pai x Filho.

A mensagem de erro ao exportar Widget fazia menção à diferença entre versões do Fluig, mas atualmente isso confunde os usuários.