### PR TITLE
Permite selecionar um local diferente para salvar os servidores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Lista de atualizações da Extensão.
 
+## 2.11.0
+
+Adiciona a opção de selecionar um local diferente para salvar o arquivo de configuração de servidores.
+
+Essa opção visa atender à necessidade de usuários que utilizam o VS Code para tratar vários projetos simultâneos
+e ter todos os servidores configurados em um único arquivo garante praticidade para esses usuários. Também pode
+trazer um pouco mais de segurança para os usuários que, erroneamente, não colocam o arquivo de servidores no `.gitignore`.
+
 ## 2.10.1
 
 Atualizado o método de leitura de cookies no login por navegador, pois a leitura de cookie no contexto da página estava

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Há a opção de indicar que efetuará o login via Navegador. Essa opção é ú
 
 Ao clicar em um servidor é possível visualizar alguns comandos disponíveis. Com eles podemos consultar dataset, serviços etc.
 
+Por padrão o arquivo de configuração é salvo na pasta `.vscode` do seu Workspace, porém é possível alterar o local de salvamento
+do arquivo de configuração de servidores, bastando clicar no icone de edição (ao lado do botão "Adicionar Servidor"). Caso já tenha
+um arquivo de configuração pode copiá-lo para o novo local e só configurar o VS Code para apontar para ele. Arquivos existentes não
+serão apagados ao serem selecionados, diferente do alerta que o VS Code emite.
+
 ### Consultar Dataset
 
 Ao clicar no servidor será disponibilizada a opção Dataset. Nela você pode consultar um dataset do servidor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "2.10.1",
+            "version": "2.11.0",
             "devDependencies": {
                 "@popperjs/core": "^2.11.8",
                 "@types/glob": "^8.1.0",
@@ -114,9 +114,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -187,9 +187,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1070,9 +1070,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.8.11",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-            "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+            "version": "0.8.12",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+            "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1384,15 +1384,15 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/axios-ntlm": {
@@ -1406,6 +1406,16 @@
                 "des.js": "^1.1.0",
                 "dev-null": "^0.1.1",
                 "js-md4": "^0.3.2"
+            }
+        },
+        "node_modules/axios/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/b4a": {
@@ -1573,9 +1583,9 @@
             }
         },
         "node_modules/basic-ftp": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
-            "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+            "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1643,9 +1653,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2645,9 +2655,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3028,9 +3038,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-            "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4376,9 +4386,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -5067,9 +5077,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5512,9 +5522,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "2.10.1",
+    "version": "2.11.0",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {
@@ -131,6 +131,15 @@
                 "icon": {
                     "light": "dist/images/light/add.svg",
                     "dark": "dist/images/dark/add.svg"
+                }
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.changeServerConfigPath",
+                "title": "Alterar Caminho para o Arquivo de Configuração de Servidores",
+                "category": "Fluig",
+                "icon": {
+                    "light": "dist/images/light/edit.svg",
+                    "dark": "dist/images/dark/edit.svg"
                 }
             },
             {
@@ -385,13 +394,13 @@
                     "group": "navigation"
                 },
                 {
-                    "command": "fluiggers-fluig-vscode-extension.refreshServer",
+                    "command": "fluiggers-fluig-vscode-extension.changeServerConfigPath",
                     "when": "view == fluiggers-fluig-vscode-extension.servers",
                     "group": "navigation"
                 },
                 {
-                    "command": "fluiggers-fluig-vscode-extension.datasetView",
-                    "when": "view == fluiggers-fluig-vscode-extension.datasetViewList",
+                    "command": "fluiggers-fluig-vscode-extension.refreshServer",
+                    "when": "view == fluiggers-fluig-vscode-extension.servers",
                     "group": "navigation"
                 }
             ],
@@ -530,7 +539,13 @@
                 "properties": {
                     "fluiggers.browserPath": {
                         "type": "string",
-                        "description": "Caminho do seu Navegador",
+                        "description": "Caminho do seu Navegador para Autenticação MFA",
+                        "default": "",
+                        "scope": "machine"
+                    },
+                    "fluiggers.serverConfigPath": {
+                        "type": "string",
+                        "description": "Caminho do seu Arquivo de Configuração de Servidores",
                         "default": "",
                         "scope": "machine"
                     }

--- a/src/extensions/ServerExtension.ts
+++ b/src/extensions/ServerExtension.ts
@@ -17,6 +17,10 @@ export class ServerExtension {
             () => serverItemProvider.add()
         ));
         context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.changeServerConfigPath",
+            () => serverItemProvider.changeConfigPath()
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
             "fluiggers-fluig-vscode-extension.refreshServer",
             () => serverItemProvider.refresh()
         ));

--- a/src/providers/ServerItemProvider.ts
+++ b/src/providers/ServerItemProvider.ts
@@ -6,7 +6,6 @@ import { ServerView } from '../views/ServerView';
 import { Server } from '../models/Server';
 import { DatasetView } from '../views/DatasetView';
 
-
 export class ServerItem extends vscode.TreeItem {
     constructor(
         public context: vscode.ExtensionContext,
@@ -75,6 +74,33 @@ export class ServerItemProvider implements vscode.TreeDataProvider<ServerItem> {
     public add(): void {
         const serverView = new ServerView(this.context);
         serverView.show();
+    }
+
+    public async changeConfigPath(): Promise<void> {
+        const config = vscode.workspace.getConfiguration("fluiggers");
+        let customPath = config.get<string>("serverConfigPath", "");
+
+        const fileUri = await vscode.window.showSaveDialog({
+            title: "Arquivo de Configuração de Servidores (não será sobreescrito)",
+            saveLabel: "Selecione",
+            defaultUri: customPath.length ? vscode.Uri.file(customPath) : undefined,
+            filters: {
+                "JSON": ["json"],
+            },
+        });
+
+        if (fileUri) {
+            customPath = fileUri.fsPath;
+        } else {
+            customPath = "";
+            vscode.window.showInformationMessage("Caminho do arquivo de configuração será na pasta .vscode");
+        }
+
+        await config.update('serverConfigPath', customPath, vscode.ConfigurationTarget.Global);
+
+        ServerService.updateConfigPath();
+        this.serverConfigListener();
+        this.refresh();
     }
 
     public delete(serverItem: ServerItem): void {

--- a/src/services/ServerService.ts
+++ b/src/services/ServerService.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { window, Uri, QuickPickItem } from "vscode";
+import { window, workspace, Uri, QuickPickItem } from "vscode";
 import { UtilsService } from "./UtilsService";
 import { ServerConfig } from "../models/ServerConfig";
 import { ServerDTO } from "../models/ServerDTO";
@@ -10,8 +10,8 @@ const SERVER_CONFIG_VERSION = '1.0.0';
 
 export class ServerService {
     private static PATH = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode').fsPath;
-    private static FILE_SERVER_CONFIG = Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode', 'servers.json').fsPath;
     private static SELECTED_SERVER: string = "";
+    private static FILE_SERVER_CONFIG = ServerService.getConfigPath();
 
     /**
      * Adiciona um novo servidor
@@ -227,5 +227,21 @@ export class ServerService {
         ServerService.writeServerConfig(serverConfig);
 
         return true;
+    }
+
+    private static getConfigPath(): string {
+        const config = workspace.getConfiguration('fluiggers');
+        let customPath = config.get<string>('serverConfigPath', "");
+
+        if (customPath != "") {
+            return customPath;
+        }
+
+        return Uri.joinPath(UtilsService.getWorkspaceUri(), '.vscode', 'servers.json').fsPath;
+    }
+
+    public static updateConfigPath(): void {
+        ServerService.FILE_SERVER_CONFIG = ServerService.getConfigPath();
+        ServerService.getFileServerConfig();
     }
 }


### PR DESCRIPTION
A intenção é atender ao pedido de usuários que precisam manter vários servidores já carregados no VS Code, pois atendem vários projetos ao mesmo tempo e ter servidores espalhados pelos projetos pode ser um desgaste de qualidade de vida.