### PR TITLE
feat: importação de processos Fluig como .process Graphiti 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Lista de atualizações da Extensão.
 
+## 2.12.0
+
+Adiciona os comandos **Importar Processo** e **Importar Vários Processos** para baixar processos publicados em um servidor Fluig e gravá-los localmente como arquivos `.process` no formato Graphiti BPMN2 (idêntico ao gerado pelo plugin Eclipse Fluig). Eventos `.js` e literais `.properties` vinculados a cada processo também são baixados automaticamente para `workflow/scripts/` e `workflow/.resources/literals/`.
+
+A conversão real é feita por um pacote externo Java (`fluig-process-runtime`) carregado pela extensão. Para deixar o fluxo seamless, foram adicionados:
+
+- Comando **Instalar Runtime fluig-process**: baixa o ZIP do runtime de uma URL configurável e o instala em `globalStorageUri`, configurando `fluiggers.fluigProcessHome` automaticamente.
+- Comando **Remover Runtime fluig-process** e **Verificar Runtime fluig-process** para troubleshooting.
+- Diálogo de onboarding na primeira execução com botão "Baixar e instalar" (1-clique).
+- Reaproveita as credenciais do servidor já configurado na extensão — sem novo prompt de senha.
+- Configurações novas: `fluiggers.fluigProcessHome`, `fluiggers.fluigProcessCliPath`, `fluiggers.fluigProcessRuntimeUrl`.
+
+Veja a seção *Importar Processo do Servidor* no README para pré-requisitos (Java 11+) e detalhes do pacote externo.
+
 ## 2.11.0
 
 Adiciona a opção de selecionar um local diferente para salvar o arquivo de configuração de servidores.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Após abrir a pasta do projeto Fluig as seguintes funcionalidades serão disponi
 - [Novo Evento de Formulário](#novo-evento-de-formulário)
 - [Importar Formulário e Importar Vários Formulários](#importar-formulário)
 - [Exportar Formulário](#exportar-formulário)
+- [Importar Processo do Servidor](#importar-processo-do-servidor)
 - [Novo Evento de Processo](#novo-evento-de-processo)
 - [Exportar Evento de Processo](#exportar-evento-de-processo)
 - [Novo Evento Global](#novo-evento-global)
@@ -194,6 +195,42 @@ Ao editar um formulário você pode indicar se deve ou não atualizar a versão.
 
 É obrigatório que o nome do arquivo HTML seja igual ao nome do diretório em que está armazenado (o nome do formulário no servidor
 é indiferente), pois é isso que determina qual é o arquivo principal do formulário.
+
+## Importar Processo do Servidor
+
+Esses comandos baixam um ou mais processos publicados em um servidor Fluig e geram localmente os arquivos `.process` no formato Graphiti BPMN2 — exatamente o mesmo formato produzido pelo plugin Eclipse Fluig oficial. Os eventos `.js` e literais `.properties` vinculados a cada processo também são baixados e gravados automaticamente em `workflow/scripts/` e `workflow/.resources/literals/`.
+
+Há dois comandos:
+
+- **Importar Processo**: lista os processos do servidor selecionado, permite escolher um e o baixa.
+- **Importar Vários Processos**: mesma lista, mas com seleção múltipla e barra de progresso.
+
+### Como funciona
+
+A conversão de `.process` Graphiti depende de bibliotecas Java específicas do Eclipse e do TOTVS Fluig que não podem ser reproduzidas em TypeScript. Por isso a extensão delega o trabalho a um **pacote externo** chamado `fluig-process` (CLI Java + bundle headless do Eclipse), invocado via `child_process`. O fluxo na extensão fica seamless mesmo assim porque:
+
+- Credenciais do servidor já configurado na extensão são reaproveitadas — **sem novo prompt de senha**.
+- Na primeira execução, se o runtime não estiver instalado, um diálogo oferece **Baixar e instalar** com um clique. O ZIP é baixado de uma URL configurável (GitHub Release) e instalado em `globalStorageUri`. A configuração `fluiggers.fluigProcessHome` é gravada automaticamente.
+- Alternativamente, você pode apontar `fluiggers.fluigProcessHome` para uma instalação existente do `fluig-process-runtime`.
+
+### Pré-requisitos
+
+- **Java 11 ou superior** disponível no `PATH`.
+- Acesso de rede para baixar o ZIP do runtime (~50 MB) na primeira vez (ou um runtime já instalado localmente).
+
+### Comandos auxiliares
+
+- **Instalar Runtime fluig-process**: baixa e instala o ZIP manualmente.
+- **Remover Runtime fluig-process**: remove o runtime de `globalStorageUri` e limpa a configuração.
+- **Verificar Runtime fluig-process**: diagnóstico rápido (Java, runtime e CLI).
+
+### Configurações relacionadas
+
+| Configuração | Descrição |
+| --- | --- |
+| `fluiggers.fluigProcessHome` | Diretório do runtime fluig-process (preenchido automaticamente após "Instalar"). |
+| `fluiggers.fluigProcessCliPath` | (Opcional) Caminho explícito para o JAR `fluig-process-cli`. Use quando o runtime estiver num layout de pastas fora do padrão — por exemplo, um build local do Maven onde o JAR fica em `target/`. Se vazio, a extensão procura automaticamente em `<home>/cli/` e `<home>/lib/`. |
+
 
 ## Novo Evento de Processo
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "fluiggers-fluig-vscode-extension",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "devDependencies": {
                 "@popperjs/core": "^2.11.8",
+                "@types/adm-zip": "^0.5.8",
                 "@types/glob": "^8.1.0",
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^20.12.12",
@@ -16,6 +17,7 @@
                 "@typescript-eslint/eslint-plugin": "^7.9.0",
                 "@typescript-eslint/parser": "^7.9.0",
                 "@vscode/test-electron": "^2.3.10",
+                "adm-zip": "^0.5.17",
                 "bootstrap": "^5.3.3",
                 "bufferutil": "^4.1.0",
                 "datatables.net-bs5": "^2.0.7",
@@ -527,6 +529,16 @@
             "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/adm-zip": {
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+            "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
@@ -1127,6 +1139,16 @@
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/adm-zip": {
+            "version": "0.5.17",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+            "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0"
             }
         },
         "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "2.11.0",
+    "version": "2.12.0",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {
@@ -102,6 +102,31 @@
             {
                 "command": "fluiggers-fluig-vscode-extension.exportMechanism",
                 "title": "Exportar Mecanismo Customizado",
+                "category": "Fluig"
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.importProcess",
+                "title": "Importar Processo",
+                "category": "Fluig"
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.importManyProcesses",
+                "title": "Importar Vários Processos",
+                "category": "Fluig"
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.installFluigProcessRuntime",
+                "title": "Instalar Runtime fluig-process",
+                "category": "Fluig"
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.uninstallFluigProcessRuntime",
+                "title": "Remover Runtime fluig-process",
+                "category": "Fluig"
+            },
+            {
+                "command": "fluiggers-fluig-vscode-extension.checkFluigProcessRuntime",
+                "title": "Verificar Runtime fluig-process",
                 "category": "Fluig"
             },
             {
@@ -374,6 +399,14 @@
                     "group": "1_Fluig4Workflow@6"
                 },
                 {
+                    "command": "fluiggers-fluig-vscode-extension.importManyProcesses",
+                    "group": "1_Fluig4Workflow@7"
+                },
+                {
+                    "command": "fluiggers-fluig-vscode-extension.importProcess",
+                    "group": "1_Fluig4Workflow@8"
+                },
+                {
                     "command": "fluiggers-fluig-vscode-extension.newWidget",
                     "group": "1_Fluig5WCM@1"
                 },
@@ -518,6 +551,13 @@
                 "contents": "Nenhum Servidor encontrado.\n[Adicionar Servidor](command:fluiggers-fluig-vscode-extension.addServer)"
             }
         ],
+        "languages": [
+            {
+                "id": "ftl",
+                "aliases": ["FreeMarker", "ftl"],
+                "extensions": [".ftl"]
+            }
+        ],
         "snippets": [
             {
                 "language": "html",
@@ -548,6 +588,24 @@
                         "description": "Caminho do seu Arquivo de Configuração de Servidores",
                         "default": "",
                         "scope": "machine"
+                    },
+                    "fluiggers.fluigProcessHome": {
+                        "type": "string",
+                        "markdownDescription": "Diretório da distribuição **fluig-process** (deve conter `plugins/org.eclipse.equinox.launcher_*.jar` ou `runtime/plugins/org.eclipse.equinox.launcher_*.jar`). Usado pelo comando *Importar Processo*. Exemplos:\n\n- macOS/Linux: `/Users/seu-usuario/fluig-process` ou `/opt/fluig-process`\n- Windows: `C:\\Users\\seu-usuario\\fluig-process`\n\nDeixe vazio se for usar o comando *Fluig: Instalar Runtime fluig-process*, que preenche este caminho automaticamente. Veja a seção *Importar Processo do Servidor* no README.",
+                        "default": "",
+                        "scope": "machine"
+                    },
+                    "fluiggers.fluigProcessCliPath": {
+                        "type": "string",
+                        "markdownDescription": "(Opcional) Caminho explícito para o JAR da CLI fluig-process. O arquivo costuma se chamar `fluig-process-cli.jar` ou `fluig-process-cli-<versão>.jar`. Exemplos:\n\n- `/Users/seu-usuario/fluig-process/lib/fluig-process-cli.jar`\n- `/Users/seu-usuario/fluig-process/cli/fluig-process-cli-0.1.0-SNAPSHOT.jar`\n- `C:\\Users\\seu-usuario\\fluig-process\\lib\\fluig-process-cli.jar`\n\nSe vazio, é resolvido a partir de `fluiggers.fluigProcessHome` (procura em `<home>/lib/` e `<home>/cli/`).",
+                        "default": "",
+                        "scope": "machine"
+                    },
+                    "fluiggers.eclipseInstallationPath": {
+                        "type": "string",
+                        "markdownDescription": "(Opcional) Caminho para uma instalação local do Eclipse. A extensão copia automaticamente as bibliotecas SWT (`org.eclipse.swt_*.jar` + fragment nativo da sua plataforma) desse Eclipse para `runtime/plugins/` do fluig-process — necessário porque alguns bundles TOTVS tocam em SWT durante a importação. Exemplos:\n\n- macOS: `/Applications/Eclipse.app` ou `/Applications/Eclipse.app/Contents/Eclipse`\n- Linux: `/opt/eclipse`\n- Windows: `C:\\eclipse`\n\nNão precisa configurar se o ZIP do runtime já trouxer os fragments SWT da sua plataforma.",
+                        "default": "",
+                        "scope": "machine"
                     }
                 }
             }
@@ -569,6 +627,7 @@
     },
     "devDependencies": {
         "@popperjs/core": "^2.11.8",
+        "@types/adm-zip": "^0.5.8",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.12.12",
@@ -576,6 +635,7 @@
         "@typescript-eslint/eslint-plugin": "^7.9.0",
         "@typescript-eslint/parser": "^7.9.0",
         "@vscode/test-electron": "^2.3.10",
+        "adm-zip": "^0.5.17",
         "bootstrap": "^5.3.3",
         "bufferutil": "^4.1.0",
         "datatables.net-bs5": "^2.0.7",

--- a/src/extensions/WorkflowExtension.ts
+++ b/src/extensions/WorkflowExtension.ts
@@ -4,10 +4,15 @@ import { readFileSync } from "fs";
 import { TemplateService } from "../services/TemplateService";
 import { AttributionMechanismService } from '../services/AttributionMechanismService';
 import { WorkflowService } from '../services/WorkflowService';
+import { ProcessService } from '../services/ProcessService';
+import { FluigProcessCliService } from '../services/FluigProcessCliService';
+import { FluigProcessRuntimeInstaller } from '../services/FluigProcessRuntimeInstaller';
 
 export class WorkflowExtension {
 
     public static activate(context: vscode.ExtensionContext): void {
+        FluigProcessCliService.initialize(context);
+
         context.subscriptions.push(vscode.commands.registerCommand(
             "fluiggers-fluig-vscode-extension.newWorkflowEvent",
             WorkflowExtension.createWorkflowEvent
@@ -31,6 +36,26 @@ export class WorkflowExtension {
         context.subscriptions.push(vscode.commands.registerCommand(
             "fluiggers-fluig-vscode-extension.exportMechanism",
             WorkflowExtension.exportMechanism
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.importProcess",
+            ProcessService.import
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.importManyProcesses",
+            ProcessService.importMany
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.installFluigProcessRuntime",
+            () => FluigProcessRuntimeInstaller.install(context)
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.uninstallFluigProcessRuntime",
+            () => FluigProcessRuntimeInstaller.uninstall(context)
+        ));
+        context.subscriptions.push(vscode.commands.registerCommand(
+            "fluiggers-fluig-vscode-extension.checkFluigProcessRuntime",
+            FluigProcessCliService.diagnose
         ));
     }
 

--- a/src/models/ProcessDefinitionDTO.ts
+++ b/src/models/ProcessDefinitionDTO.ts
@@ -1,0 +1,5 @@
+export interface ProcessDefinitionDTO {
+    processId: string;
+    processDescription: string;
+    active: boolean;
+}

--- a/src/services/FluigProcessCliService.ts
+++ b/src/services/FluigProcessCliService.ts
@@ -1,0 +1,619 @@
+import {
+    commands,
+    ExtensionContext,
+    Uri,
+    window,
+    workspace,
+} from 'vscode';
+import {
+    copyFileSync,
+    existsSync,
+    mkdirSync,
+    promises as fsp,
+    readdirSync,
+    rmSync,
+    writeFileSync,
+} from 'fs';
+import { join, resolve } from 'path';
+import { spawn, execFile } from 'child_process';
+import AdmZip = require('adm-zip');
+import { ServerDTO } from '../models/ServerDTO';
+import { ProcessDefinitionDTO } from '../models/ProcessDefinitionDTO';
+import { UtilsService } from './UtilsService';
+import { FluigProcessRuntimeInstaller } from './FluigProcessRuntimeInstaller';
+
+interface CliResultJson {
+    status?: string;
+    operation?: string;
+    processId?: string;
+    processFile?: string;
+    message?: string;
+    exitCode?: number | string;
+    processes?: Array<{ processId: string; processDescription: string; active?: boolean }>;
+    warnings?: string[];
+    validationProblems?: string[];
+}
+
+export class FluigProcessCliService {
+    private static context: ExtensionContext;
+    private static javaAvailable: boolean | undefined;
+
+    public static initialize(context: ExtensionContext): void {
+        FluigProcessCliService.context = context;
+    }
+
+    public static locateRuntime(): string | null {
+        const candidates = [
+            workspace
+                .getConfiguration('fluiggers')
+                .get<string>('fluigProcessHome', '')
+                .trim(),
+            (process.env.FLUIG_PROCESS_HOME || '').trim(),
+            FluigProcessRuntimeInstaller.runtimeDir(FluigProcessCliService.context),
+        ];
+
+        for (const candidate of candidates) {
+            if (!candidate) {
+                continue;
+            }
+            const resolved = FluigProcessCliService.resolveRuntimeDir(candidate);
+            if (resolved) {
+                return resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private static resolveRuntimeDir(dir: string): string | null {
+        if (!dir || !existsSync(dir)) {
+            return null;
+        }
+
+        if (FluigProcessCliService.hasLauncherIn(join(dir, 'plugins'))) {
+            return dir;
+        }
+
+        const nested = join(dir, 'runtime');
+        if (FluigProcessCliService.hasLauncherIn(join(nested, 'plugins'))) {
+            return nested;
+        }
+
+        return null;
+    }
+
+    private static ensureSwtBundles(runtime: string): void {
+        const pluginsDir = join(runtime, 'plugins');
+        if (!existsSync(pluginsDir)) {
+            return;
+        }
+
+        const existing = readdirSync(pluginsDir);
+        const fragmentName = FluigProcessCliService.swtFragmentName();
+
+        const hasBase = existing.some(name =>
+            /^org\.eclipse\.swt_.*\.jar$/.test(name)
+        );
+        const hasFragment = fragmentName
+            ? existing.some(name =>
+                  new RegExp(
+                      `^org\\.eclipse\\.swt\\.${fragmentName}_.*\\.jar$`
+                  ).test(name)
+              )
+            : true;
+
+        if (!hasBase || !hasFragment) {
+            const eclipsePath = workspace
+                .getConfiguration('fluiggers')
+                .get<string>('eclipseInstallationPath', '')
+                .trim();
+
+            if (!eclipsePath) {
+                console.warn(
+                    '[fluig-process] runtime sem fragments SWT — configure fluiggers.eclipseInstallationPath para apontar a um Eclipse local, ou regere o pacote fluig-process com os fragments incluídos.'
+                );
+            } else {
+                const eclipsePlugins =
+                    FluigProcessCliService.findEclipsePluginsDir(eclipsePath);
+
+                if (!eclipsePlugins) {
+                    console.warn(
+                        `[fluig-process] não encontrei pasta plugins/ em ${eclipsePath} — fluiggers.eclipseInstallationPath inválido?`
+                    );
+                } else {
+                    const sourceFiles = readdirSync(eclipsePlugins);
+
+                    const copiedBase = FluigProcessCliService.copyMatching(
+                        sourceFiles,
+                        /^org\.eclipse\.swt_.*\.jar$/,
+                        eclipsePlugins,
+                        pluginsDir,
+                        hasBase
+                    );
+
+                    let copiedFragment = false;
+                    if (fragmentName) {
+                        copiedFragment = FluigProcessCliService.copyMatching(
+                            sourceFiles,
+                            new RegExp(
+                                `^org\\.eclipse\\.swt\\.${fragmentName}_.*\\.jar$`
+                            ),
+                            eclipsePlugins,
+                            pluginsDir,
+                            hasFragment
+                        );
+                    }
+
+                    if (copiedBase || copiedFragment) {
+                        FluigProcessCliService.invalidateOsgiCache(runtime);
+                    }
+                }
+            }
+        }
+
+        FluigProcessCliService.extractSwtNatives(runtime, fragmentName);
+    }
+
+    private static extractSwtNatives(
+        runtime: string,
+        fragmentName: string | null
+    ): void {
+        if (!fragmentName) {
+            return;
+        }
+
+        const pluginsDir = join(runtime, 'plugins');
+        const nativesDir = join(runtime, 'swt-natives');
+
+        if (existsSync(nativesDir) && readdirSync(nativesDir).length > 0) {
+            return;
+        }
+
+        const fragmentRegex = new RegExp(
+            `^org\\.eclipse\\.swt\\.${fragmentName}_.*\\.jar$`
+        );
+        const fragmentJar = readdirSync(pluginsDir).find(name =>
+            fragmentRegex.test(name)
+        );
+
+        if (!fragmentJar) {
+            return;
+        }
+
+        try {
+            mkdirSync(nativesDir, { recursive: true });
+            const zip = new AdmZip(join(pluginsDir, fragmentJar));
+            let extracted = 0;
+            for (const entry of zip.getEntries()) {
+                if (entry.isDirectory) {
+                    continue;
+                }
+                const name = entry.entryName;
+                if (
+                    name.endsWith('.jnilib') ||
+                    name.endsWith('.dylib') ||
+                    name.endsWith('.so') ||
+                    name.endsWith('.dll')
+                ) {
+                    const base = name.includes('/')
+                        ? name.substring(name.lastIndexOf('/') + 1)
+                        : name;
+                    writeFileSync(join(nativesDir, base), entry.getData());
+                    extracted++;
+                }
+            }
+            if (extracted > 0) {
+                console.log(
+                    `[fluig-process] extraídas ${extracted} native libs do ${fragmentJar} para ${nativesDir}`
+                );
+            }
+        } catch (error: any) {
+            console.warn(
+                `[fluig-process] falha extraindo natives SWT: ${error.message || error}`
+            );
+        }
+    }
+
+    private static invalidateOsgiCache(runtime: string): void {
+        const cacheDir = join(runtime, 'configuration', 'org.eclipse.osgi');
+        if (!existsSync(cacheDir)) {
+            return;
+        }
+        try {
+            rmSync(cacheDir, { recursive: true, force: true });
+            console.log(`[fluig-process] cache OSGi invalidado em ${cacheDir}`);
+        } catch (error: any) {
+            console.warn(
+                `[fluig-process] falha ao invalidar cache OSGi: ${error.message || error}`
+            );
+        }
+    }
+
+    private static copyMatching(
+        names: string[],
+        pattern: RegExp,
+        from: string,
+        to: string,
+        alreadyPresent: boolean
+    ): boolean {
+        if (alreadyPresent) {
+            return false;
+        }
+        const match = names.find(name => pattern.test(name));
+        if (!match) {
+            console.warn(
+                `[fluig-process] bundle ${pattern} não encontrado em ${from}`
+            );
+            return false;
+        }
+        const dest = join(to, match);
+        if (existsSync(dest)) {
+            return false;
+        }
+        try {
+            copyFileSync(join(from, match), dest);
+            console.log(`[fluig-process] copiado ${match} para ${to}`);
+            return true;
+        } catch (error: any) {
+            console.warn(
+                `[fluig-process] falha ao copiar ${match}: ${error.message || error}`
+            );
+            return false;
+        }
+    }
+
+    private static findEclipsePluginsDir(eclipseRoot: string): string | null {
+        const candidates = [
+            join(eclipseRoot, 'plugins'),
+            join(eclipseRoot, 'Contents', 'Eclipse', 'plugins'),
+        ];
+        return candidates.find(p => existsSync(p)) ?? null;
+    }
+
+    private static swtFragmentName(): string | null {
+        switch (process.platform) {
+            case 'darwin':
+                return process.arch === 'arm64'
+                    ? 'cocoa\\.macosx\\.aarch64'
+                    : 'cocoa\\.macosx\\.x86_64';
+            case 'linux':
+                return process.arch === 'arm64'
+                    ? 'gtk\\.linux\\.aarch64'
+                    : 'gtk\\.linux\\.x86_64';
+            case 'win32':
+                return process.arch === 'arm64'
+                    ? 'win32\\.win32\\.aarch64'
+                    : 'win32\\.win32\\.x86_64';
+            default:
+                return null;
+        }
+    }
+
+    private static hasLauncherIn(pluginsDir: string): boolean {
+        try {
+            const files = readdirSync(pluginsDir);
+            return files.some(name =>
+                /^org\.eclipse\.equinox\.launcher_.*\.jar$/.test(name)
+            );
+        } catch {
+            return false;
+        }
+    }
+
+    public static locateCliJar(runtime: string | null): string | null {
+        const fromSetting = workspace
+            .getConfiguration('fluiggers')
+            .get<string>('fluigProcessCliPath', '')
+            .trim();
+
+        if (fromSetting && existsSync(fromSetting)) {
+            return fromSetting;
+        }
+
+        if (runtime) {
+            const roots = [runtime, join(runtime, '..')];
+            const candidateDirs = ['cli', 'lib'];
+            for (const root of roots) {
+                for (const sub of candidateDirs) {
+                    const dir = join(root, sub);
+                    if (!existsSync(dir)) {
+                        continue;
+                    }
+                    const jar = readdirSync(dir).find(
+                        name =>
+                            name.startsWith('fluig-process-cli') &&
+                            name.endsWith('.jar')
+                    );
+                    if (jar) {
+                        return join(dir, jar);
+                    }
+                }
+            }
+        }
+
+        const inTree = resolve(
+            FluigProcessCliService.context.extensionPath,
+            'eclipse-research/research/fluig-process-cli/target/fluig-process-cli-0.1.0-SNAPSHOT.jar'
+        );
+        if (existsSync(inTree)) {
+            return inTree;
+        }
+
+        return null;
+    }
+
+    public static async ensureReady(): Promise<boolean> {
+        const runtime = FluigProcessCliService.locateRuntime();
+        const jar = FluigProcessCliService.locateCliJar(runtime);
+        const javaOk = await FluigProcessCliService.javaWorks();
+
+        console.log('[fluig-process] ensureReady v3 (swt-natives extractor)', {
+            runtime,
+            jar,
+            javaWorks: javaOk,
+        });
+
+        if (runtime && jar && javaOk) {
+            FluigProcessCliService.ensureSwtBundles(runtime);
+            return true;
+        }
+
+        const choice = await window.showErrorMessage(
+            'Runtime fluig-process não encontrado. Ele é necessário para importar processos como .process Graphiti.',
+            { modal: true },
+            'Baixar e instalar',
+            'Abrir configurações',
+            'Ver instruções'
+        );
+
+        if (choice === 'Baixar e instalar') {
+            const installed = await FluigProcessRuntimeInstaller.install(
+                FluigProcessCliService.context
+            );
+            if (installed && (await FluigProcessCliService.javaWorks())) {
+                return true;
+            }
+            return false;
+        }
+
+        if (choice === 'Abrir configurações') {
+            await commands.executeCommand(
+                'workbench.action.openSettings',
+                'fluiggers.fluigProcess'
+            );
+            return false;
+        }
+
+        if (choice === 'Ver instruções') {
+            const readme = Uri.joinPath(
+                FluigProcessCliService.context.extensionUri,
+                'README.md'
+            );
+            await commands.executeCommand('markdown.showPreview', readme);
+            return false;
+        }
+
+        return false;
+    }
+
+    public static async diagnose(): Promise<void> {
+        const runtime = FluigProcessCliService.locateRuntime();
+        const jar = FluigProcessCliService.locateCliJar(runtime);
+        const javaOk = await FluigProcessCliService.javaWorks();
+
+        const lines = [
+            `Java disponível: ${javaOk ? 'sim' : 'não'}`,
+            `FLUIG_PROCESS_HOME resolvido: ${runtime ?? '(nenhum)'}`,
+            `CLI jar: ${jar ?? '(nenhum)'}`,
+        ];
+
+        if (!runtime || !jar || !javaOk) {
+            window.showWarningMessage(lines.join(' | '));
+            return;
+        }
+
+        try {
+            const result = await FluigProcessCliService.runRaw(['--help'], {}, jar, runtime);
+            window.showInformationMessage(
+                `Runtime OK. ${lines.join(' | ')}. CLI responde: ${result.stdout.split('\n')[0]}`
+            );
+        } catch (error: any) {
+            window.showErrorMessage(
+                `CLI presente mas falhou ao executar: ${error.message || error}`
+            );
+        }
+    }
+
+    public static async list(server: ServerDTO): Promise<ProcessDefinitionDTO[]> {
+        const result = await FluigProcessCliService.runJson(['list'], server);
+
+        return (result.processes || []).map(item => ({
+            processId: item.processId,
+            processDescription: item.processDescription || '',
+            active: Boolean(item.active),
+        }));
+    }
+
+    public static async import(
+        server: ServerDTO,
+        processId: string,
+        workspaceDir: string,
+        outFile: string
+    ): Promise<{ processFile: string; warnings: string[] }> {
+        const args = [
+            'import',
+            '--process-id',
+            processId,
+            '--project',
+            'fluig-process',
+            '--out',
+            outFile,
+            '--overwrite',
+        ];
+
+        const result = await FluigProcessCliService.runJson(args, server, workspaceDir);
+
+        return {
+            processFile: result.processFile || outFile,
+            warnings: result.warnings || [],
+        };
+    }
+
+    private static async runJson(
+        args: string[],
+        server: ServerDTO,
+        workspaceDir?: string
+    ): Promise<CliResultJson> {
+        const runtime = FluigProcessCliService.locateRuntime();
+        const jar = FluigProcessCliService.locateCliJar(runtime);
+
+        if (!runtime || !jar) {
+            throw new Error('Runtime fluig-process não configurado.');
+        }
+
+        const fullArgs = [
+            ...args,
+            '--server-url',
+            UtilsService.getHost(server),
+            '--user',
+            server.username,
+            '--company-id',
+            String(server.companyId),
+            '--json',
+        ];
+
+        if (workspaceDir) {
+            fullArgs.push('--workspace', workspaceDir);
+        }
+
+        const env = {
+            ...process.env,
+            FLUIG_PROCESS_HOME: runtime,
+            FLUIG_PASSWORD: server.password,
+        };
+
+        console.log('[fluig-process] spawn', {
+            jar,
+            runtime,
+            args: fullArgs,
+        });
+
+        const { stdout, stderr, code } = await FluigProcessCliService.runRaw(
+            fullArgs,
+            env,
+            jar,
+            runtime
+        );
+
+        console.log('[fluig-process] exit', code);
+        if (stderr.trim()) {
+            console.log('[fluig-process] stderr:\n' + stderr);
+        }
+        if (stdout.trim()) {
+            console.log('[fluig-process] stdout:\n' + stdout);
+        }
+
+        if (!stdout.trim()) {
+            throw new Error(
+                `CLI fluig-process não retornou nada (exit ${code}). stderr:\n${stderr.trim() || '(vazio)'}`
+            );
+        }
+
+        const parsed = FluigProcessCliService.parseJsonResult(stdout);
+
+        if (parsed.status && parsed.status !== 'ok') {
+            const details = [parsed.message, ...(parsed.validationProblems || [])]
+                .filter(Boolean)
+                .join('\n');
+            throw new Error(details || `CLI retornou status ${parsed.status}`);
+        }
+
+        if (code !== 0 && !parsed.status) {
+            throw new Error(
+                `CLI fluig-process saiu com código ${code}. stderr:\n${stderr.trim() || '(vazio)'}`
+            );
+        }
+
+        return parsed;
+    }
+
+    private static parseJsonResult(stdout: string): CliResultJson {
+        const trimmed = stdout.trim();
+        if (!trimmed) {
+            return {};
+        }
+
+        const start = trimmed.indexOf('{');
+        const end = trimmed.lastIndexOf('}');
+        if (start === -1 || end === -1 || end <= start) {
+            throw new Error(`Saída da CLI não é JSON:\n${trimmed}`);
+        }
+
+        try {
+            return JSON.parse(trimmed.substring(start, end + 1));
+        } catch (error: any) {
+            throw new Error(`Falha ao parsear JSON da CLI: ${error.message}`);
+        }
+    }
+
+    private static runRaw(
+        args: string[],
+        env: NodeJS.ProcessEnv,
+        jar: string,
+        runtime: string
+    ): Promise<{ stdout: string; stderr: string; code: number }> {
+        return new Promise((resolvePromise, rejectPromise) => {
+            const baseToolOptions = (env.JAVA_TOOL_OPTIONS || '').trim();
+            const extras: string[] = ['-Dosgi.clean=true'];
+
+            const nativesDir = join(runtime, 'swt-natives');
+            if (existsSync(nativesDir)) {
+                extras.push(`-Dswt.library.path=${nativesDir}`);
+                extras.push(`-Djava.library.path=${nativesDir}`);
+            }
+
+            const javaToolOptions = [baseToolOptions, ...extras]
+                .filter(Boolean)
+                .join(' ');
+
+            const child = spawn('java', ['-jar', jar, ...args], {
+                env: {
+                    FLUIG_PROCESS_HOME: runtime,
+                    ...env,
+                    JAVA_TOOL_OPTIONS: javaToolOptions,
+                },
+            });
+
+            let stdout = '';
+            let stderr = '';
+
+            child.stdout.on('data', chunk => (stdout += chunk.toString()));
+            child.stderr.on('data', chunk => (stderr += chunk.toString()));
+
+            child.on('error', err => rejectPromise(err));
+            child.on('close', code => {
+                const exit = code ?? -1;
+                if (exit !== 0 && !stdout.trim()) {
+                    rejectPromise(
+                        new Error(
+                            `java -jar fluig-process-cli falhou (exit ${exit}): ${stderr.trim()}`
+                        )
+                    );
+                    return;
+                }
+                resolvePromise({ stdout, stderr, code: exit });
+            });
+        });
+    }
+
+    private static async javaWorks(): Promise<boolean> {
+        if (FluigProcessCliService.javaAvailable !== undefined) {
+            return FluigProcessCliService.javaAvailable;
+        }
+        const result = await new Promise<boolean>(resolvePromise => {
+            execFile('java', ['-version'], err => resolvePromise(!err));
+        });
+        FluigProcessCliService.javaAvailable = result;
+        return result;
+    }
+}

--- a/src/services/FluigProcessCliService.ts
+++ b/src/services/FluigProcessCliService.ts
@@ -368,7 +368,7 @@ export class FluigProcessCliService {
         }
 
         const choice = await window.showErrorMessage(
-            'Runtime fluig-process não encontrado. Ele é necessário para importar processos como .process Graphiti.',
+            'Runtime Fluig Process Runtime não encontrado. Ele é necessário para importar processos como .process Graphiti.',
             { modal: true },
             'Baixar e instalar',
             'Abrir configurações',
@@ -376,9 +376,18 @@ export class FluigProcessCliService {
         );
 
         if (choice === 'Baixar e instalar') {
+            if (!javaOk) {
+                await window.showWarningMessage(
+                    'Java não foi encontrado no PATH. O Fluig Process Runtime requer Java (JDK 11 ou superior) instalado para executar a importação de processos. Instale o Java e tente novamente.',
+                    { modal: true }
+                );
+                return false;
+            }
+
             const installed = await FluigProcessRuntimeInstaller.install(
                 FluigProcessCliService.context
             );
+            FluigProcessCliService.javaAvailable = undefined;
             if (installed && (await FluigProcessCliService.javaWorks())) {
                 return true;
             }

--- a/src/services/FluigProcessCliService.ts
+++ b/src/services/FluigProcessCliService.ts
@@ -9,7 +9,6 @@ import {
     copyFileSync,
     existsSync,
     mkdirSync,
-    promises as fsp,
     readdirSync,
     rmSync,
     writeFileSync,
@@ -74,9 +73,19 @@ export class FluigProcessCliService {
             return dir;
         }
 
-        const nested = join(dir, 'runtime');
-        if (FluigProcessCliService.hasLauncherIn(join(nested, 'plugins'))) {
-            return nested;
+        try {
+            const entries = readdirSync(dir, { withFileTypes: true });
+            for (const entry of entries) {
+                if (!entry.isDirectory()) {
+                    continue;
+                }
+                const candidate = join(dir, entry.name);
+                if (FluigProcessCliService.hasLauncherIn(join(candidate, 'plugins'))) {
+                    return candidate;
+                }
+            }
+        } catch {
+            // ignore unreadable dirs
         }
 
         return null;

--- a/src/services/FluigProcessRuntimeInstaller.ts
+++ b/src/services/FluigProcessRuntimeInstaller.ts
@@ -1,0 +1,247 @@
+import {
+    ConfigurationTarget,
+    ExtensionContext,
+    ProgressLocation,
+    Uri,
+    window,
+    workspace,
+} from 'vscode';
+import { createWriteStream, existsSync, promises as fsp } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { request as httpsRequest } from 'https';
+import { request as httpRequest, IncomingMessage } from 'http';
+import { URL } from 'url';
+import AdmZip = require('adm-zip');
+
+const RUNTIME_URL =
+    'https://github.com/isacfg/fluig-process-runtime/releases/download/fluig-process-v1/fluig-process-runtime.zip';
+
+export class FluigProcessRuntimeInstaller {
+    public static runtimeDir(context: ExtensionContext): string {
+        return join(context.globalStorageUri.fsPath, 'fluig-process');
+    }
+
+    public static async install(context: ExtensionContext): Promise<string | undefined> {
+        const url = RUNTIME_URL;
+        const targetDir = FluigProcessRuntimeInstaller.runtimeDir(context);
+
+        try {
+            return await window.withProgress(
+                {
+                    location: ProgressLocation.Notification,
+                    title: 'Instalando runtime fluig-process',
+                    cancellable: false,
+                },
+                async progress => {
+                    progress.report({ message: 'Baixando ZIP...' });
+
+                    const zipPath = join(
+                        tmpdir(),
+                        `fluig-process-runtime-${Date.now()}.zip`
+                    );
+                    await FluigProcessRuntimeInstaller.download(url, zipPath, progress);
+
+                    progress.report({ message: 'Extraindo...' });
+                    await fsp.mkdir(targetDir, { recursive: true });
+                    await FluigProcessRuntimeInstaller.cleanDir(targetDir);
+
+                    await new Promise<void>((resolveExtract, rejectExtract) => {
+                        setImmediate(() => {
+                            try {
+                                const zip = new AdmZip(zipPath);
+                                zip.extractAllTo(targetDir, true);
+                                resolveExtract();
+                            } catch (err) {
+                                rejectExtract(err);
+                            }
+                        });
+                    });
+                    await fsp.unlink(zipPath).catch(() => undefined);
+
+                    progress.report({ message: 'Validando...' });
+                    const resolvedHome = await FluigProcessRuntimeInstaller.resolveHomeAfterExtract(
+                        targetDir
+                    );
+
+                    if (!resolvedHome) {
+                        throw new Error(
+                            'ZIP extraído não contém plugins/org.eclipse.equinox.launcher_*.jar'
+                        );
+                    }
+
+                    await workspace
+                        .getConfiguration('fluiggers')
+                        .update(
+                            'fluigProcessHome',
+                            resolvedHome,
+                            ConfigurationTarget.Global
+                        );
+
+                    window.showInformationMessage(
+                        `Runtime fluig-process instalado em ${resolvedHome}`
+                    );
+
+                    return resolvedHome;
+                }
+            );
+        } catch (error: any) {
+            window.showErrorMessage(
+                `Falha ao instalar runtime fluig-process: ${error.message || error}`
+            );
+            return undefined;
+        }
+    }
+
+    public static async uninstall(context: ExtensionContext): Promise<void> {
+        const targetDir = FluigProcessRuntimeInstaller.runtimeDir(context);
+
+        try {
+            if (existsSync(targetDir)) {
+                await fsp.rm(targetDir, { recursive: true, force: true });
+            }
+
+            await workspace
+                .getConfiguration('fluiggers')
+                .update('fluigProcessHome', '', ConfigurationTarget.Global);
+
+            window.showInformationMessage('Runtime fluig-process removido.');
+        } catch (error: any) {
+            window.showErrorMessage(
+                `Falha ao remover runtime fluig-process: ${error.message || error}`
+            );
+        }
+    }
+
+    private static async cleanDir(dir: string): Promise<void> {
+        const entries = await fsp.readdir(dir).catch(() => []);
+        await Promise.all(
+            entries.map(name =>
+                fsp
+                    .rm(join(dir, name), { recursive: true, force: true })
+                    .catch(err => {
+                        console.warn(
+                            `[fluig-process] falha ao limpar ${join(dir, name)}: ${err.message || err}`
+                        );
+                    })
+            )
+        );
+    }
+
+    private static async resolveHomeAfterExtract(targetDir: string): Promise<string | null> {
+        if (await FluigProcessRuntimeInstaller.hasLauncher(targetDir)) {
+            return targetDir;
+        }
+
+        const entries = await fsp.readdir(targetDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const candidate = join(targetDir, entry.name);
+            if (await FluigProcessRuntimeInstaller.hasLauncher(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static async hasLauncher(dir: string): Promise<boolean> {
+        const plugins = join(dir, 'plugins');
+        const runtimePlugins = join(dir, 'runtime', 'plugins');
+        const candidates = [plugins, runtimePlugins];
+
+        for (const folder of candidates) {
+            try {
+                const files = await fsp.readdir(folder);
+                if (files.some(name => /^org\.eclipse\.equinox\.launcher_.*\.jar$/.test(name))) {
+                    return true;
+                }
+            } catch {
+                // ignore missing folder
+            }
+        }
+        return false;
+    }
+
+    private static download(
+        url: string,
+        destination: string,
+        progress: { report: (value: { message?: string; increment?: number }) => void }
+    ): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const fail = (err: Error) => {
+                fsp.unlink(destination).catch(() => undefined);
+                reject(err);
+            };
+
+            const followRedirect = (currentUrl: string, redirects: number) => {
+                if (redirects > 8) {
+                    fail(new Error('Excesso de redirecionamentos ao baixar runtime.'));
+                    return;
+                }
+
+                const parsed = new URL(currentUrl);
+                const requester = parsed.protocol === 'http:' ? httpRequest : httpsRequest;
+
+                const req = requester(
+                    {
+                        method: 'GET',
+                        protocol: parsed.protocol,
+                        hostname: parsed.hostname,
+                        port: parsed.port,
+                        path: parsed.pathname + parsed.search,
+                        headers: { 'User-Agent': 'fluig-vscode-extension' },
+                    },
+                    (res: IncomingMessage) => {
+                        if (
+                            res.statusCode &&
+                            res.statusCode >= 300 &&
+                            res.statusCode < 400 &&
+                            res.headers.location
+                        ) {
+                            res.resume();
+                            const next = new URL(res.headers.location, currentUrl).toString();
+                            followRedirect(next, redirects + 1);
+                            return;
+                        }
+
+                        if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+                            fail(
+                                new Error(
+                                    `HTTP ${res.statusCode} ao baixar ${currentUrl}`
+                                )
+                            );
+                            res.resume();
+                            return;
+                        }
+
+                        const total = Number(res.headers['content-length'] || 0);
+                        let received = 0;
+                        const file = createWriteStream(destination);
+
+                        res.on('data', chunk => {
+                            received += chunk.length;
+                            if (total > 0) {
+                                const pct = ((received / total) * 100).toFixed(0);
+                                progress.report({
+                                    message: `Baixando ZIP... ${pct}%`,
+                                });
+                            }
+                        });
+                        res.pipe(file);
+
+                        file.on('finish', () => file.close(() => resolve()));
+                        file.on('error', fail);
+                        res.on('error', fail);
+                    }
+                );
+
+                req.on('error', fail);
+                req.end();
+            };
+
+            followRedirect(url, 0);
+        });
+    }
+}

--- a/src/services/ProcessService.ts
+++ b/src/services/ProcessService.ts
@@ -1,0 +1,381 @@
+import { ProgressLocation, QuickPickItem, Uri, window } from 'vscode';
+import { mkdtempSync, promises as fsp, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, dirname } from 'path';
+import { glob } from 'glob';
+import { ServerDTO } from '../models/ServerDTO';
+import { ProcessDefinitionDTO } from '../models/ProcessDefinitionDTO';
+import { ServerService } from './ServerService';
+import { UtilsService } from './UtilsService';
+import { FluigProcessCliService } from './FluigProcessCliService';
+
+type OverwriteChoice = 'overwrite' | 'skip' | 'cancel';
+
+export class ProcessService {
+    public static async import(): Promise<void> {
+        try {
+            const server = await ServerService.getSelect();
+            if (!server) {
+                return;
+            }
+
+            if (!(await FluigProcessCliService.ensureReady())) {
+                return;
+            }
+
+            const process = await ProcessService.getOptionSelected(server);
+            if (!process) {
+                return;
+            }
+
+            const overwrite = await ProcessService.askOverwrite([process.processId]);
+            if (overwrite === 'cancel') {
+                return;
+            }
+
+            await window.withProgress(
+                {
+                    location: ProgressLocation.Notification,
+                    title: `Importando processo ${process.processId}`,
+                    cancellable: false,
+                },
+                async () => {
+                    await ProcessService.runImport(server, process.processId, overwrite);
+                }
+            );
+
+            const target = ProcessService.targetProcessUri(process.processId);
+            if (existsSync(target.fsPath)) {
+                window.showTextDocument(target);
+                window.showInformationMessage(
+                    `Processo ${process.processId} importado.`
+                );
+            } else {
+                window.showWarningMessage(
+                    `CLI terminou sem erros, mas ${target.fsPath} não foi criado. Veja Developer Tools > Console.`
+                );
+            }
+        } catch (error: any) {
+            console.error('[ProcessService.import] falhou', error);
+            window.showErrorMessage(
+                `Falha ao importar processo: ${error?.message || error}`
+            );
+        }
+    }
+
+    public static async importMany(): Promise<void> {
+        try {
+            await ProcessService.importManyInner();
+        } catch (error: any) {
+            console.error('[ProcessService.importMany] falhou', error);
+            window.showErrorMessage(
+                `Falha ao importar processos: ${error?.message || error}`
+            );
+        }
+    }
+
+    private static async importManyInner(): Promise<void> {
+        const server = await ServerService.getSelect();
+        if (!server) {
+            return;
+        }
+
+        if (!(await FluigProcessCliService.ensureReady())) {
+            return;
+        }
+
+        const processes = await ProcessService.getOptionsSelected(server);
+        if (!processes.length) {
+            return;
+        }
+
+        const overwrite = await ProcessService.askOverwrite(
+            processes.map(p => p.processId)
+        );
+        if (overwrite === 'cancel') {
+            return;
+        }
+
+        let imported = 0;
+        const failures: Array<{ id: string; error: string }> = [];
+
+        await window.withProgress(
+            {
+                location: ProgressLocation.Notification,
+                title: 'Importando processos',
+                cancellable: false,
+            },
+            async progress => {
+                const increment = 100 / processes.length;
+                for (const process of processes) {
+                    progress.report({
+                        message: process.processId,
+                        increment,
+                    });
+                    try {
+                        const result = await ProcessService.runImport(
+                            server,
+                            process.processId,
+                            overwrite
+                        );
+                        if (result === 'skipped') {
+                            continue;
+                        }
+                        imported++;
+                    } catch (error: any) {
+                        failures.push({
+                            id: process.processId,
+                            error: error.message || String(error),
+                        });
+                    }
+                }
+            }
+        );
+
+        if (failures.length) {
+            window.showWarningMessage(
+                `${imported} processos importados. ${failures.length} falharam:\n` +
+                    failures.map(f => `- ${f.id}: ${f.error}`).join('\n')
+            );
+        } else {
+            window.showInformationMessage(`${imported} processos importados.`);
+        }
+    }
+
+    private static async runImport(
+        server: ServerDTO,
+        processId: string,
+        overwriteChoice: OverwriteChoice
+    ): Promise<'imported' | 'skipped'> {
+        const targetProcess = ProcessService.targetProcessUri(processId);
+
+        if (existsSync(targetProcess.fsPath)) {
+            if (overwriteChoice === 'skip') {
+                return 'skipped';
+            }
+        }
+
+        const tmpWorkspace = mkdtempSync(join(tmpdir(), 'fluig-vscode-import-'));
+        const safeId = processId.replace(/\//g, '_');
+        const cliOut = join(tmpWorkspace, 'out', `${safeId}.process`);
+        let imported = false;
+
+        try {
+            await fsp.mkdir(dirname(cliOut), { recursive: true });
+
+            try {
+                await FluigProcessCliService.import(
+                    server,
+                    processId,
+                    tmpWorkspace,
+                    cliOut
+                );
+            } catch (error: any) {
+                const logs = await ProcessService.collectEclipseLogs(tmpWorkspace);
+                if (logs) {
+                    console.error(
+                        '[ProcessService.runImport] Eclipse logs:\n' + logs
+                    );
+                    error.message =
+                        (error.message || String(error)) +
+                        '\n\nLogs do Eclipse (resumido — completo no Developer Console):\n' +
+                        ProcessService.headAndTail(logs, 2500, 1500);
+                }
+                throw error;
+            }
+
+            const projectRoot = join(tmpWorkspace, 'fluig-process');
+            await ProcessService.copyArtifacts(safeId, projectRoot, cliOut);
+            imported = true;
+
+            return 'imported';
+        } finally {
+            if (imported) {
+                await fsp.rm(tmpWorkspace, { recursive: true, force: true }).catch(
+                    () => undefined
+                );
+            } else {
+                console.log(
+                    `[ProcessService] workspace preservado para inspeção: ${tmpWorkspace}`
+                );
+            }
+        }
+    }
+
+    private static async collectEclipseLogs(tmpWorkspace: string): Promise<string> {
+        const sources: string[] = [
+            join(tmpWorkspace, '.metadata', '.log'),
+        ];
+
+        const parts: string[] = [];
+
+        for (const path of sources) {
+            try {
+                if (existsSync(path)) {
+                    const content = await fsp.readFile(path, 'utf8');
+                    if (content.trim()) {
+                        parts.push(`--- ${path} ---\n${content}`);
+                    }
+                }
+            } catch {
+                // ignore
+            }
+        }
+
+        return parts.join('\n\n');
+    }
+
+    private static headAndTail(text: string, headMax: number, tailMax: number): string {
+        if (text.length <= headMax + tailMax) {
+            return text;
+        }
+        return (
+            text.slice(0, headMax) +
+            '\n\n... (omitido o meio do log) ...\n\n' +
+            text.slice(-tailMax)
+        );
+    }
+
+    private static async copyArtifacts(
+        safeId: string,
+        projectRoot: string,
+        cliOut: string
+    ): Promise<void> {
+        const wsRoot = UtilsService.getWorkspaceUri().fsPath;
+
+        const diagramsDir = join(wsRoot, 'workflow', 'diagrams');
+        await fsp.mkdir(diagramsDir, { recursive: true });
+
+        const sourceProcess = existsSync(cliOut)
+            ? cliOut
+            : join(projectRoot, 'workflow', 'diagrams', `${safeId}.process`);
+
+        if (!existsSync(sourceProcess)) {
+            throw new Error(
+                `Arquivo .process não encontrado após import: ${sourceProcess}`
+            );
+        }
+
+        await fsp.copyFile(sourceProcess, join(diagramsDir, `${safeId}.process`));
+
+        const scriptsSrc = join(projectRoot, 'workflow', 'scripts');
+        if (existsSync(scriptsSrc)) {
+            const scriptsDest = join(wsRoot, 'workflow', 'scripts');
+            await fsp.mkdir(scriptsDest, { recursive: true });
+            const scripts = await glob(`${safeId}.*.js`, { cwd: scriptsSrc });
+            await Promise.all(
+                scripts.map(name =>
+                    fsp.copyFile(join(scriptsSrc, name), join(scriptsDest, name))
+                )
+            );
+        }
+
+        const literalsSrc = join(projectRoot, 'workflow', '.resources', 'literals');
+        if (existsSync(literalsSrc)) {
+            const literalsDest = join(wsRoot, 'workflow', '.resources', 'literals');
+            await fsp.mkdir(literalsDest, { recursive: true });
+            const literals = await glob(`${safeId}_*.properties`, { cwd: literalsSrc });
+            await Promise.all(
+                literals.map(name =>
+                    fsp.copyFile(join(literalsSrc, name), join(literalsDest, name))
+                )
+            );
+        }
+    }
+
+    private static targetProcessUri(processId: string): Uri {
+        const safeId = processId.replace(/\//g, '_');
+        return Uri.joinPath(
+            UtilsService.getWorkspaceUri(),
+            'workflow',
+            'diagrams',
+            `${safeId}.process`
+        );
+    }
+
+    private static async askOverwrite(ids: string[]): Promise<OverwriteChoice> {
+        const existing = ids.filter(id => existsSync(ProcessService.targetProcessUri(id).fsPath));
+
+        if (!existing.length) {
+            return 'overwrite';
+        }
+
+        const detail =
+            existing.length === 1
+                ? `O processo "${existing[0]}" já existe em workflow/diagrams.`
+                : `${existing.length} processos já existem em workflow/diagrams:\n- ${existing.join('\n- ')}`;
+
+        const choice = await window.showWarningMessage(
+            'Alguns processos já estão importados.',
+            { modal: true, detail },
+            'Sobrescrever',
+            'Pular existentes'
+        );
+
+        if (choice === 'Sobrescrever') {
+            return 'overwrite';
+        }
+        if (choice === 'Pular existentes') {
+            return 'skip';
+        }
+        return 'cancel';
+    }
+
+    private static async getOptionSelected(
+        server: ServerDTO
+    ): Promise<ProcessDefinitionDTO | undefined> {
+        const processes = await ProcessService.fetchList(server);
+        if (!processes.length) {
+            return undefined;
+        }
+
+        const items: (QuickPickItem & { dto: ProcessDefinitionDTO })[] = processes.map(p => ({
+            label: p.processId,
+            detail: p.processDescription,
+            description: p.active === false ? '(inativo)' : undefined,
+            dto: p,
+        }));
+
+        const picked = await window.showQuickPick(items, {
+            placeHolder: 'Selecione o processo para importar',
+            matchOnDetail: true,
+        });
+
+        return picked?.dto;
+    }
+
+    private static async getOptionsSelected(
+        server: ServerDTO
+    ): Promise<ProcessDefinitionDTO[]> {
+        const processes = await ProcessService.fetchList(server);
+        if (!processes.length) {
+            return [];
+        }
+
+        const items: (QuickPickItem & { dto: ProcessDefinitionDTO })[] = processes.map(p => ({
+            label: p.processId,
+            detail: p.processDescription,
+            description: p.active === false ? '(inativo)' : undefined,
+            dto: p,
+        }));
+
+        const picked = await window.showQuickPick(items, {
+            placeHolder: 'Selecione os processos para importar',
+            canPickMany: true,
+            matchOnDetail: true,
+        });
+
+        return (picked || []).map(item => item.dto);
+    }
+
+    private static async fetchList(server: ServerDTO): Promise<ProcessDefinitionDTO[]> {
+        return window.withProgress(
+            {
+                location: ProgressLocation.Notification,
+                title: 'Buscando lista de processos no servidor',
+                cancellable: false,
+            },
+            () => FluigProcessCliService.list(server)
+        );
+    }
+}


### PR DESCRIPTION
Closes #68

## Visão Geral

Adiciona suporte à **importação de processos Fluig** diretamente de um servidor, gerando arquivos `.process` no formato Graphiti BPMN2 — o mesmo formato produzido pelo plugin oficial do Eclipse Fluig — salvos em `workflow/diagrams/` dentro do workspace.

Esta feature depende de um novo pacote externo: **[fluig-process-runtime](https://github.com/isacfg/fluig-process-runtime)**, uma ferramenta Java autônoma que é u wrapper do runtime Eclipse/Equinox para interagir com as classes proprietárias da plataforma Fluig de forma headless. A extensão gerencia automaticamente a instalação e invocação desse runtime.

---

## Nova Dependência: `fluig-process-runtime`

> 📦 Repositório atual: [`isacfg/fluig-process-runtime`](https://github.com/isacfg/fluig-process-runtime)
> *(ver sugestão de mover para a org `fluiggers` ao final)*

O `fluig-process-runtime` é uma ferramenta Java standalone que permite importar e exportar processos BPM da plataforma Fluig/ECM em modo **headless** — sem precisar abrir o Eclipse. Ela foi criada porque as classes do plugin TOTVS Fluig Designer só funcionam dentro de um container OSGi/Equinox, tornando impossível reutilizá-las diretamente numa extensão Node.js.

A extensão VS Code baixa automaticamente o runtime em `globalStorageUri/fluig-process/` ao rodar o comando **"Fluig: Instalar Fluig Process Runtime"**.

---

## Como o `fluig-process-runtime` funciona

O runtime opera em **dois níveis** que se comunicam via arquivos JSON temporários com permissões restritas (owner-only read/write):

### 1. CLI Tier (`fluig-process-cli`)
Ponto de entrada invocado pela extensão. Responsável por:
- Parsear argumentos (`import` / `export` / `list` / `render-svg`)
- Resolver senha (env `FLUIG_PASSWORD`, prompt interativo, ou argumento)
- Criar arquivos JSON de request/result com permissões restritas
- Bootstrapar o processo Equinox com o launcher correto
- Capturar stdout/stderr e retornar o JSON de resultado

### 2. Headless Equinox Bundle (`fluig-process-headless`)
Bundle OSGi que roda dentro do container Equinox. Responsável por:
- Receber o JSON de request
- Usar **reflection** para chamar as classes internas TOTVS/Fluig (não há API pública)
- Realizar comunicação SOAP com o servidor Fluig
- Manipular diagramas EMF/Graphiti (`.process`)
- Exportar SVG de prévia dos diagramas
- Escrever o JSON de result

### Protocolo de comunicação

```json
// Request (escrito pela CLI)
{
  "operation": "import | export | list | render-svg",
  "serverUrl": "https://fluig.empresa.com.br",
  "user": "admin",
  "companyId": "1",
  "processId": "meu_processo",
  "out": "/tmp/meu_processo.process",
  "overwrite": true
}

// Result (escrito pelo bundle Equinox)
{
  "status": "ok | error",
  "processId": "meu_processo",
  "processFile": "/tmp/meu_processo.process",
  "exitCode": 0,
  "warnings": [],
  "processList": [...]
}
```

### Fluxo de execução

```
Extensão VS Code
  └─► FluigProcessCliService.spawn(java, [args])
        └─► fluig-process-cli.jar
              ├─ cria request.json (chmod 600)
              ├─ bootstrapa equinox launcher
              └─► FluigProcessApplication (OSGi bundle)
                    ├─ lê request.json
                    ├─ HeadlessProcessService.import()
                    │   └─ FluigReflection → classes TOTVS via SOAP
                    └─ escreve result.json
          ◄── lê result.json → retorna para extensão
```

### Estrutura da distribuição

```
fluig-process/
├── lib/fluig-process-cli.jar      # CLI JAR compilado
└── runtime/
    └── plugins/                   # Plugins Eclipse (Equinox + bundles TOTVS)
        ├── org.eclipse.equinox.launcher_*.jar
        ├── org.eclipse.swt.<platform>_*.jar  # Fragment nativo por plataforma
        └── ...bundles TOTVS/Fluig...
```

---

## Feature habilitada por esta PR

### ✅ Importação de processos (funcional)

Baixa um processo do servidor Fluig e gera o arquivo `.process` localmente, copiando todos os artefatos para os diretórios corretos do workspace:

| Artefato | Destino |
|----------|---------|
| Diagrama `.process` | `workflow/diagrams/` |
| Scripts de eventos `.js` | `workflow/scripts/` |
| Literais `.properties` | `workflow/.resources/literals/` |

**Fluxo do usuário:**
1. Seleciona o servidor Fluig configurado
2. A extensão verifica/instala o runtime automaticamente
3. Lista os processos disponíveis no servidor
4. Usuário seleciona um ou vários processos
5. Define comportamento de overwrite (perguntar / sempre / nunca)
6. Arquivos extraídos no workspace e `.process` aberto no editor

---

## Possibilidades futuras habilitadas pelo `fluig-process-runtime`

### 🔄 Exportação de processos — ~90% funcional no runtime, falta integrar na extensão

O runtime já implementa a operação `export` de forma quase completa. Ela publica um arquivo `.process` local de volta ao servidor Fluig com suporte a:

- Criar um processo novo (`--mode new`) ou publicar nova versão (`--mode version`)
- Flag `--automatize` para publicar ECM XML + SVG junto ao diagrama
- Validação BPMN2 contra as regras TOTVS antes de publicar
- Fallback para publicação via XML ECM quando o endpoint SOAP `BPMProcessService` estiver depreciado no servidor

```bash
# Já funciona via CLI hoje
fluig-process export \
  --server-url https://fluig.empresa.com.br \
  --user admin \
  --file workflow/diagrams/meu_processo.process \
  --process-id meu_processo \
  --mode version \
  --automatize
```

O que falta para integrar na extensão: um comando `exportProcess` em `ProcessService.ts` que leia o arquivo `.process` aberto no editor e invoque `FluigProcessCliService.export()`. A infraestrutura de autenticação, localização do runtime e comunicação já existe — é o caminho inverso do import.

**Impacto:** completaria o ciclo de vida de desenvolvimento de processos BPM inteiramente no VS Code, eliminando a necessidade do Eclipse.

### 🧪 Editor de processos dentro do VS Code — pesquisa inicial, viável

A pesquisa inicial aponta que é viável construir um **Custom Editor no VS Code** para arquivos `.process`, renderizando o próprio diagrama EMF/Graphiti diretamente numa WebView — sem depender do Eclipse para visualização ou edição.

Isso eliminaria definitivamente a dependência do Eclipse Fluig Designer — o editor de processos passaria a viver inteiramente na extensão VS Code.

**Estado atual:** pesquisa inicial. Ainda não implementado na extensão.

---

## Comandos adicionados

| Comando | Descrição |
|---------|-----------|
| Fluig: Importar Processo do Servidor | Importa um único processo com seleção interativa |
| Fluig: Importar Múltiplos Processos | Importa vários processos com barra de progresso |
| Fluig: Instalar Fluig Process Runtime | Baixa e instala o runtime do GitHub Releases |
| Fluig: Desinstalar Fluig Process Runtime | Remove o runtime instalado |
| Fluig: Verificar Fluig Process Runtime | Diagnóstico: Java, localização do runtime, JAR CLI |

---

## Configurações adicionadas

| Setting | Descrição |
|---------|-----------|
| `fluiggers.fluigProcessHome` | Caminho para o diretório do runtime (preenchido automaticamente após instalar) |
| `fluiggers.fluigProcessCliPath` | Caminho explícito para o `fluig-process-cli.jar` (opcional) |
| `fluiggers.eclipseInstallationPath` | Caminho para instalação local do Eclipse para copiar SWT bundles (opcional, avançado) |

---

## Requisitos

- **Java 11+** disponível no `PATH`
- Servidor Fluig configurado na extensão
- Runtime instalado via **"Fluig: Instalar Fluig Process Runtime"** (automático na primeira execução)

---

## Arquivos modificados/adicionados

| Arquivo | Tipo | Descrição |
|---------|------|-----------|
| `src/services/ProcessService.ts` | ✅ Novo | Orquestra import único e em lote, diálogos de overwrite, cópia de artefatos |
| `src/services/FluigProcessCliService.ts` | ✅ Novo | Wrapper do CLI Java: localiza runtime, extrai SWT nativo por plataforma, invoca JAR |
| `src/services/FluigProcessRuntimeInstaller.ts` | ✅ Novo | Baixa e extrai o ZIP do runtime do GitHub Releases, configura settings |
| `src/models/ProcessDefinitionDTO.ts` | ✅ Novo | DTO: `processId`, `processDescription`, `active` |
| `src/extensions/WorkflowExtension.ts` | ✏️ Modificado | Registra os 5 novos comandos e inicializa `FluigProcessCliService` |
| `package.json` | ✏️ Modificado | Define comandos, settings, deps (`adm-zip`, `@types/adm-zip`) |
| `README.md` | ✏️ Modificado | Seção "Importar Processo do Servidor" com pré-requisitos e fluxo |
| `CHANGELOG.md` | ✏️ Modificado | v2.12.0 |

---

## Sugestão: mover `fluig-process-runtime` para a org `fluiggers`

O `fluig-process-runtime` atualmente está em [`isacfg/fluig-process-runtime`](https://github.com/isacfg/fluig-process-runtime). Como ele é a peça central que habilita o ciclo de vida completo de processos Fluig no VS Code, faz sentido movê-lo para a organização **`fluiggers`** pelos seguintes motivos:

- **Governança comunitária:** outros colaboradores da extensão poderiam contribuir e manter o runtime
- **Consistência:** todos os artefatos do ecossistema Fluig VSCode estariam na mesma org
- **Confiança:** o link de download em `FluigProcessRuntimeInstaller.ts` apontaria para um repo da org, não um repositório pessoal
- **CI/CD compartilhado:** builds e releases poderiam usar a infraestrutura da organização
- **Visibilidade:** issues e discussões sobre o runtime estariam centralizadas junto à extensão

---

## Caveats conhecidos

### ⚠️ Servidor temporário no `.process` importado

Ao importar um processo, o arquivo `.process` gerado vem com um servidor temporário configurado internamente — o usuário precisa trocar manualmente para o servidor correto após a importação. Não impacta o funcionamento, mas é um passo manual necessário por enquanto.

**Melhoria futura planejada:** sincronização dos servidores configurados no Eclipse com os servidores da extensão VS Code. Com isso, seria possível importar o processo já com o servidor correto mapeado automaticamente, eliminando esse ajuste manual.

---

## Observações de teste

- ✅ Desenvolvimento e testes iniciais realizados no **macOS (arm64)**
- ⚠️ É fundamental coletar feedback sobre o comportamento em **Windows** e **Linux**, bem como em diferentes versões do Fluig
- A extração de bibliotecas SWT nativas já trata os três sistemas operacionais, mas não foi testado além do macOS e Linux

---

## Screenshots

<img width="454" height="97" alt="image" src="https://github.com/user-attachments/assets/8c702e3b-9232-4cf6-b665-2d76fbb86d0e" />
<img width="618" height="131" alt="image" src="https://github.com/user-attachments/assets/6418c4e5-2396-4e37-9350-385bfca0859d" />
<img width="456" height="57" alt="image" src="https://github.com/user-attachments/assets/ec63d512-ff0d-4d6a-b149-e5e57dfb225b" />


---
